### PR TITLE
Add AI usage and GitHub activity charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 
 # OS
 .DS_Store
+.vercel

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,7 @@
+# Env — never commit secrets
+.env
+.env.*
+!.env.example
+
+# OS
+.DS_Store

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,2 +1,21 @@
 PUBLIC_SUPABASE_URL=""
 PUBLIC_SUPABASE_ANON_KEY=""
+
+# Autumn / Summer AI-usage tracking. Secret key from app.useautumn.com (am_sk_...).
+# Server-only — read via $env/dynamic/private. Never expose to the client.
+AUTUMN_SECRET_KEY=""
+
+# GitHub contribution graph. Any token can read a public user's contribution calendar — a scopeless
+# classic PAT (github.com/settings/tokens) or a fine-grained token works. Server-only.
+GITHUB_TOKEN=""
+# Whose calendar to show. Defaults to "janburzinski" when unset.
+GITHUB_USERNAME=""
+
+# PlanetScale Postgres. DATABASE_URL is the pooled connection (:6432, used at runtime by the app
+# and cron); DATABASE_DIRECT_URL is the direct connection (:5432, used by drizzle-kit for DDL).
+DATABASE_URL=""
+DATABASE_DIRECT_URL=""
+
+# Shared secret guarding the /api/sync cron endpoint. Vercel Cron sends it as
+# `Authorization: Bearer <CRON_SECRET>`. Generate any long random string.
+CRON_SECRET=""

--- a/web/drizzle.config.ts
+++ b/web/drizzle.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from 'drizzle-kit';
+
+// Migrations / push run against the DIRECT (:5432) connection — DDL over the PgBouncer pool (:6432)
+// breaks. drizzle-kit loads variables from `.env` automatically.
+const url = process.env.DATABASE_DIRECT_URL;
+if (!url) throw new Error('DATABASE_DIRECT_URL is not set');
+
+export default defineConfig({
+	dialect: 'postgresql',
+	schema: './src/lib/server/db/schema.ts',
+	out: './drizzle',
+	dbCredentials: { url }
+});

--- a/web/package.json
+++ b/web/package.json
@@ -21,7 +21,11 @@
 		"format": "prettier --write .",
 		"lint": "prettier --check . && eslint .",
 		"deploy": "wrangler deploy",
-		"dev:remote": "wrangler dev --remote"
+		"dev:remote": "wrangler dev --remote",
+		"db:push": "drizzle-kit push",
+		"db:generate": "drizzle-kit generate",
+		"db:migrate": "drizzle-kit migrate",
+		"db:studio": "drizzle-kit studio"
 	},
 	"devDependencies": {
 		"@eslint/compat": "^1.4.1",
@@ -31,6 +35,8 @@
 		"@sveltejs/adapter-vercel": "^6.3.3",
 		"@sveltejs/kit": "^2.50.2",
 		"@sveltejs/vite-plugin-svelte": "^6.2.4",
+		"@types/pg": "^8.20.0",
+		"drizzle-kit": "^0.31.10",
 		"eslint": "^9.39.2",
 		"eslint-config-prettier": "^10.1.8",
 		"eslint-plugin-svelte": "^3.14.0",
@@ -49,6 +55,9 @@
 		"@fontsource/geist": "^5.2.9",
 		"@fontsource/geist-mono": "^5.2.8",
 		"@fontsource/inter": "^5.2.8",
-		"lucide-svelte": "^0.563.0"
+		"@vercel/functions": "^3.7.5",
+		"drizzle-orm": "^0.45.2",
+		"lucide-svelte": "^0.563.0",
+		"pg": "^8.22.0"
 	}
 }

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -17,9 +17,18 @@ importers:
       '@fontsource/inter':
         specifier: ^5.2.8
         version: 5.2.8
+      '@vercel/functions':
+        specifier: ^3.7.5
+        version: 3.7.5(ws@8.18.0)
+      drizzle-orm:
+        specifier: ^0.45.2
+        version: 0.45.2(@cloudflare/workers-types@4.20260317.1)(@types/pg@8.20.0)(pg@8.22.0)
       lucide-svelte:
         specifier: ^0.563.0
         version: 0.563.0(svelte@5.50.0)
+      pg:
+        specifier: ^8.22.0
+        version: 8.22.0
     devDependencies:
       '@eslint/compat':
         specifier: ^1.4.1
@@ -29,19 +38,25 @@ importers:
         version: 9.39.2
       '@sveltejs/adapter-cloudflare':
         specifier: ^7.2.8
-        version: 7.2.8(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)))(wrangler@4.76.0(@cloudflare/workers-types@4.20260317.1))
+        version: 7.2.8(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(wrangler@4.76.0(@cloudflare/workers-types@4.20260317.1))
       '@sveltejs/adapter-node':
         specifier: ^5.3.3
-        version: 5.5.4(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)))
+        version: 5.5.4(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))
       '@sveltejs/adapter-vercel':
         specifier: ^6.3.3
-        version: 6.3.4(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)))(rollup@4.60.2)
+        version: 6.3.4(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(rollup@4.60.2)
       '@sveltejs/kit':
         specifier: ^2.50.2
-        version: 2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0))
+        version: 2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.2.4
-        version: 6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0))
+        version: 6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0))
+      '@types/pg':
+        specifier: ^8.20.0
+        version: 8.20.0
+      drizzle-kit:
+        specifier: ^0.31.10
+        version: 0.31.10
       eslint:
         specifier: ^9.39.2
         version: 9.39.2
@@ -77,7 +92,7 @@ importers:
         version: 8.54.0(eslint@9.39.2)(typescript@5.9.3)
       vite:
         specifier: ^7.3.1
-        version: 7.3.1(@types/node@24.1.0)
+        version: 7.3.1(@types/node@24.1.0)(tsx@4.23.0)
       wrangler:
         specifier: ^4.76.0
         version: 4.76.0(@cloudflare/workers-types@4.20260317.1)
@@ -134,8 +149,25 @@ packages:
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
 
+  '@drizzle-team/brocli@0.10.2':
+    resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
+
   '@emnapi/runtime@1.9.1':
     resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+
+  '@esbuild-kit/core-utils@3.3.2':
+    resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
+    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+
+  '@esbuild/aix-ppc64@0.25.12':
+    resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -155,6 +187,18 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.18.20':
+    resolution: {integrity: sha512-Nz4rJcchGDtENV0eMKUNa6L12zz2zBDXuhj/Vjh18zGqB44Bi7MBMSXjgunJgjRhCmKOjnPuZp4Mb6OKqtMHLQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.25.12':
+    resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.27.2':
     resolution: {integrity: sha512-pvz8ZZ7ot/RBphf8fv60ljmaoydPU12VuXHImtAs0XhLLw+EXBi2BLe3OYSBslR4rryHvweW5gmkKFwTiFy6KA==}
     engines: {node: '>=18'}
@@ -171,6 +215,18 @@ packages:
     resolution: {integrity: sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.18.20':
+    resolution: {integrity: sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.12':
+    resolution: {integrity: sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.27.2':
@@ -191,6 +247,18 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.18.20':
+    resolution: {integrity: sha512-8GDdlePJA8D6zlZYJV/jnrRAi6rOiNaCC/JclcXpB+KIuvfBN4owLtgzY2bsxnx666XjJx2kDPUmnTtR8qKQUg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.12':
+    resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.27.2':
     resolution: {integrity: sha512-z8Ank4Byh4TJJOh4wpz8g2vDy75zFL0TlZlkUkEwYXuPSgX8yzep596n6mT7905kA9uHZsf/o2OJZubl2l3M7A==}
     engines: {node: '>=18'}
@@ -209,6 +277,18 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.18.20':
+    resolution: {integrity: sha512-bxRHW5kHU38zS2lPTPOyuyTm+S+eobPUnTNkdJEfAddYgEcll4xkT8DB9d2008DtTbl7uJag2HuE5NZAZgnNEA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.25.12':
+    resolution: {integrity: sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.27.2':
     resolution: {integrity: sha512-davCD2Zc80nzDVRwXTcQP/28fiJbcOwvdolL0sOiOsbwBa72kegmVU0Wrh1MYrbuCL98Omp5dVhQFWRKR2ZAlg==}
     engines: {node: '>=18'}
@@ -225,6 +305,18 @@ packages:
     resolution: {integrity: sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.18.20':
+    resolution: {integrity: sha512-pc5gxlMDxzm513qPGbCbDukOdsGtKhfxD1zJKXjCCcU7ju50O7MeAZ8c4krSJcOIJGFR+qx21yMMVYwiQvyTyQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.12':
+    resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.27.2':
@@ -245,6 +337,18 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.18.20':
+    resolution: {integrity: sha512-yqDQHy4QHevpMAaxhhIwYPMv1NECwOvIpGCZkECn8w2WFHXjEwrBn3CeNIYsibZ/iZEUemj++M26W3cNR5h+Tw==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.25.12':
+    resolution: {integrity: sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.27.2':
     resolution: {integrity: sha512-lS/9CN+rgqQ9czogxlMcBMGd+l8Q3Nj1MFQwBZJyoEKI50XGxwuzznYdwcav6lpOGv5BqaZXqvBSiB/kJ5op+g==}
     engines: {node: '>=18'}
@@ -261,6 +365,18 @@ packages:
     resolution: {integrity: sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.18.20':
+    resolution: {integrity: sha512-tgWRPPuQsd3RmBZwarGVHZQvtzfEBOreNuxEMKFcd5DaDn2PbBxfwLcj4+aenoh7ctXcbXmOQIn8HI6mCSw5MQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.12':
+    resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.27.2':
@@ -281,6 +397,18 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.18.20':
+    resolution: {integrity: sha512-2YbscF+UL7SQAVIpnWvYwM+3LskyDmPhe31pE7/aoTMFKKzIc9lLbyGUpmmb8a8AixOL61sQ/mFh3jEjHYFvdA==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.25.12':
+    resolution: {integrity: sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.27.2':
     resolution: {integrity: sha512-hYxN8pr66NsCCiRFkHUAsxylNOcAQaxSSkHMMjcpx0si13t1LHFphxJZUiGwojB1a/Hd5OiPIqDdXONia6bhTw==}
     engines: {node: '>=18'}
@@ -297,6 +425,18 @@ packages:
     resolution: {integrity: sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.18.20':
+    resolution: {integrity: sha512-/5bHkMWnq1EgKr1V+Ybz3s1hWXok7mDFUMQ4cG10AfW3wL02PSZi5kFpYKrptDsgb2WAJIvRcDm+qIvXf/apvg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.12':
+    resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.27.2':
@@ -317,6 +457,18 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.18.20':
+    resolution: {integrity: sha512-P4etWwq6IsReT0E1KHU40bOnzMHoH73aXp96Fs8TIT6z9Hu8G6+0SHSw9i2isWrD2nbx2qo5yUqACgdfVGx7TA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.12':
+    resolution: {integrity: sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.27.2':
     resolution: {integrity: sha512-MJt5BRRSScPDwG2hLelYhAAKh9imjHK5+NE/tvnRLbIqUWa+0E9N4WNMjmp/kXXPHZGqPLxggwVhz7QP8CTR8w==}
     engines: {node: '>=18'}
@@ -333,6 +485,18 @@ packages:
     resolution: {integrity: sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.18.20':
+    resolution: {integrity: sha512-nXW8nqBTrOpDLPgPY9uV+/1DjxoQ7DoB2N8eocyq8I9XuqJ7BiAMDMf9n1xZM9TgW0J8zrquIb/A7s3BJv7rjg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.12':
+    resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.27.2':
@@ -353,6 +517,18 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.18.20':
+    resolution: {integrity: sha512-d5NeaXZcHp8PzYy5VnXV3VSd2D328Zb+9dEq5HE6bw6+N86JVPExrA6O68OPwobntbNJ0pzCpUFZTo3w0GyetQ==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.12':
+    resolution: {integrity: sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.27.2':
     resolution: {integrity: sha512-nlP2I6ArEBewvJ2gjrrkESEZkB5mIoaTswuqNFRv/WYd+ATtUpe9Y09RnJvgvdag7he0OWgEZWhviS1OTOKixw==}
     engines: {node: '>=18'}
@@ -369,6 +545,18 @@ packages:
     resolution: {integrity: sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.18.20':
+    resolution: {integrity: sha512-WHPyeScRNcmANnLQkq6AfyXRFr5D6N2sKgkFo2FqguP44Nw2eyDlbTdZwd9GYk98DZG9QItIiTlFLHJHjxP3FA==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.12':
+    resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.27.2':
@@ -389,6 +577,18 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.18.20':
+    resolution: {integrity: sha512-WSxo6h5ecI5XH34KC7w5veNnKkju3zBRLEQNY7mv5mtBmrP/MjNBCAlsM2u5hDBlS3NGcTQpoBvRzqBcRtpq1A==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.12':
+    resolution: {integrity: sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.27.2':
     resolution: {integrity: sha512-B5BOmojNtUyN8AXlK0QJyvjEZkWwy/FKvakkTDCziX95AowLZKR6aCDhG7LeF7uMCXEJqwa8Bejz5LTPYm8AvA==}
     engines: {node: '>=18'}
@@ -405,6 +605,18 @@ packages:
     resolution: {integrity: sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.18.20':
+    resolution: {integrity: sha512-+8231GMs3mAEth6Ja1iK0a1sQ3ohfcpzpRLH8uuc5/KVDFneH6jtAJLFGafpzpMRO6DzJ6AvXKze9LfFMrIHVQ==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.12':
+    resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.27.2':
@@ -425,6 +637,18 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.18.20':
+    resolution: {integrity: sha512-UYqiqemphJcNsFEskc73jQ7B9jgwjWrSayxawS6UVFZGWrAAtkzjxSqnoclCXxWtfwLdzU+vTpcNYhpn43uP1w==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.12':
+    resolution: {integrity: sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.27.2':
     resolution: {integrity: sha512-uwp2Tip5aPmH+NRUwTcfLb+W32WXjpFejTIOWZFw/v7/KnpCDKG66u4DLcurQpiYTiYwQ9B7KOeMJvLCu/OvbA==}
     engines: {node: '>=18'}
@@ -443,6 +667,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.27.2':
     resolution: {integrity: sha512-Kj6DiBlwXrPsCRDeRvGAUb/LNrBASrfqAIok+xB0LxK8CHqxZ037viF13ugfsIpePH93mX7xfJp97cyDuTZ3cw==}
     engines: {node: '>=18'}
@@ -459,6 +689,18 @@ packages:
     resolution: {integrity: sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.18.20':
+    resolution: {integrity: sha512-iO1c++VP6xUBUmltHZoMtCUdPlnPGdBom6IrO4gyKPFFVBKioIImVooR5I83nTew5UOYrk3gIJhbZh8X44y06A==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.12':
+    resolution: {integrity: sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.27.2':
@@ -479,6 +721,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.27.2':
     resolution: {integrity: sha512-DNIHH2BPQ5551A7oSHD0CKbwIA/Ox7+78/AWkbS5QoRzaqlev2uFayfSxq68EkonB+IKjiuxBFoV8ESJy8bOHA==}
     engines: {node: '>=18'}
@@ -495,6 +743,18 @@ packages:
     resolution: {integrity: sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.18.20':
+    resolution: {integrity: sha512-e5e4YSsuQfX4cxcygw/UCPIEP6wbIL+se3sxPdCiMbFLBWu0eiZOJ7WoD+ptCLrmjZBK1Wk7I6D/I3NglUGOxg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.12':
+    resolution: {integrity: sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.27.2':
@@ -515,6 +775,12 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.27.2':
     resolution: {integrity: sha512-LRBbCmiU51IXfeXk59csuX/aSaToeG7w48nMwA6049Y4J4+VbWALAuXcs+qcD04rHDuSCSRKdmY63sruDS5qag==}
     engines: {node: '>=18'}
@@ -532,6 +798,18 @@ packages:
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.18.20':
+    resolution: {integrity: sha512-kDbFRFp0YpTQVVrqUd5FTYmWo45zGaXe0X8E1G/LKFC0v8x0vWrhOWSLITcCn63lmZIxfOMXtCfti/RxN/0wnQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.25.12':
+    resolution: {integrity: sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.27.2':
     resolution: {integrity: sha512-kMtx1yqJHTmqaqHPAzKCAkDaKsffmXkPHThSfRwZGyuqyIeBvf08KSsYXl+abf5HDAPMJIPnbBfXvP2ZC2TfHg==}
@@ -551,6 +829,18 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.18.20':
+    resolution: {integrity: sha512-ddYFR6ItYgoaq4v4JmQQaAI5s7npztfV4Ag6NrhiaW0RrnOXqBkgwZLofVTlq1daVTQNhtI5oieTvkRPfZrePg==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.25.12':
+    resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.27.2':
     resolution: {integrity: sha512-Yaf78O/B3Kkh+nKABUF++bvJv5Ijoy9AN1ww904rOXZFLWVc5OLOfL56W+C8F9xn5JQZa3UX6m+IktJnIb1Jjg==}
     engines: {node: '>=18'}
@@ -569,6 +859,18 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.18.20':
+    resolution: {integrity: sha512-Wv7QBi3ID/rROT08SABTS7eV4hX26sVduqDOTe1MvGMjNd3EjOz4b7zeexIR62GTIEKrfJXKL9LFxTYgkyeu7g==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.12':
+    resolution: {integrity: sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.27.2':
     resolution: {integrity: sha512-Iuws0kxo4yusk7sw70Xa2E2imZU5HoixzxfGCdxwBdhiDgt9vX9VUCBhqcwY7/uh//78A1hMkkROMJq9l27oLQ==}
     engines: {node: '>=18'}
@@ -585,6 +887,18 @@ packages:
     resolution: {integrity: sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.18.20':
+    resolution: {integrity: sha512-kTdfRcSiDfQca/y9QIkng02avJ+NCaQvrMejlsB3RRv5sE9rRoeBPISaZpKxHELzRxZyLvNts1P27W3wV+8geQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.12':
+    resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.27.2':
@@ -1250,6 +1564,9 @@ packages:
   '@types/node@24.1.0':
     resolution: {integrity: sha512-ut5FthK5moxFKH2T1CUOC6ctR67rQRvvHdFLCD2Ql6KXmMuCrjsSsRI9UsLCm9M18BMwClv4pn327UvB7eeO1w==}
 
+  '@types/pg@8.20.0':
+    resolution: {integrity: sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==}
+
   '@types/resolve@1.20.2':
     resolution: {integrity: sha512-60BCwRFOZCQhDncwQdxxeOEEkbc5dIMccYLwbxsS4TUNeVECQ/pBJ0j09mrHOl/JJvpRPGwO9SvE4nR2Nb/a4Q==}
 
@@ -1312,10 +1629,33 @@ packages:
     resolution: {integrity: sha512-VFlhGSl4opC0bprJiItPQ1RfUhGDIBokcPwaFH4yiBCaNPeld/9VeXbiPO1cLyorQi1G1vL+ecBk1x8o1axORA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vercel/cli-config@0.2.0':
+    resolution: {integrity: sha512-fJRRRB7734BDuXZ89yBEaA2ncYhH7bWX30mk04W80J6VAfQc+4iB8lyzAdaGpFV3/vNlkt9VZt+/uoQoWX6UsQ==}
+
+  '@vercel/cli-exec@1.0.0':
+    resolution: {integrity: sha512-kQF8LGie/Hbdq9/psJxLE7owRTcqMQMhgybU04gCeR7cbQAr5t8OrjefDNColJv1QSSucFt4pLwRiARVmlOnug==}
+    engines: {node: '>= 18'}
+
+  '@vercel/functions@3.7.5':
+    resolution: {integrity: sha512-ESf8BbeDebqRUyMi09JwRbQqpLn4g6fjcVVHPsHB56j2dSqRrSHO4h3X4aaxJf6iQQjzhAtDGI2xCWQ27JE8PA==}
+    engines: {node: '>= 20'}
+    peerDependencies:
+      '@aws-sdk/credential-provider-web-identity': '*'
+      ws: '>=8'
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-web-identity':
+        optional: true
+      ws:
+        optional: true
+
   '@vercel/nft@1.10.2':
     resolution: {integrity: sha512-w+WyX5Ulmj4dtTZrxaulqrjaLZHSbnPzx75SJsTNYmotKsqn1JlLnDJa+lz5hn90HJofhl/2MAtw0mCrgM3qYw==}
     engines: {node: '>=20'}
     hasBin: true
+
+  '@vercel/oidc@3.8.0':
+    resolution: {integrity: sha512-r00laGW6Pv778RoR6M2NxX91ycSj+PBwVo+fOb9Bif+F0IyUKt25zrvBzfEzQpeAzbqOgPZyQibEWDdDFApd+A==}
+    engines: {node: '>= 20'}
 
   abbrev@3.0.1:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
@@ -1383,6 +1723,9 @@ packages:
   brace-expansion@5.0.7:
     resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
+
+  buffer-from@1.1.2:
+    resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1461,12 +1804,118 @@ packages:
   devalue@5.6.2:
     resolution: {integrity: sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==}
 
+  drizzle-kit@0.31.10:
+    resolution: {integrity: sha512-7OZcmQUrdGI+DUNNsKBn1aW8qSoKuTH7d0mYgSP8bAzdFzKoovxEFnoGQp2dVs82EOJeYycqRtciopszwUf8bw==}
+    hasBin: true
+
+  drizzle-orm@0.45.2:
+    resolution: {integrity: sha512-kY0BSaTNYWnoDMVoyY8uxmyHjpJW1geOmBMdSSicKo9CIIWkSxMIj2rkeSR51b8KAPB7m+qysjuHme5nKP+E5Q==}
+    peerDependencies:
+      '@aws-sdk/client-rds-data': '>=3'
+      '@cloudflare/workers-types': '>=4'
+      '@electric-sql/pglite': '>=0.2.0'
+      '@libsql/client': '>=0.10.0'
+      '@libsql/client-wasm': '>=0.10.0'
+      '@neondatabase/serverless': '>=0.10.0'
+      '@op-engineering/op-sqlite': '>=2'
+      '@opentelemetry/api': ^1.4.1
+      '@planetscale/database': '>=1.13'
+      '@prisma/client': '*'
+      '@tidbcloud/serverless': '*'
+      '@types/better-sqlite3': '*'
+      '@types/pg': '*'
+      '@types/sql.js': '*'
+      '@upstash/redis': '>=1.34.7'
+      '@vercel/postgres': '>=0.8.0'
+      '@xata.io/client': '*'
+      better-sqlite3: '>=7'
+      bun-types: '*'
+      expo-sqlite: '>=14.0.0'
+      gel: '>=2'
+      knex: '*'
+      kysely: '*'
+      mysql2: '>=2'
+      pg: '>=8'
+      postgres: '>=3'
+      prisma: '*'
+      sql.js: '>=1'
+      sqlite3: '>=5'
+    peerDependenciesMeta:
+      '@aws-sdk/client-rds-data':
+        optional: true
+      '@cloudflare/workers-types':
+        optional: true
+      '@electric-sql/pglite':
+        optional: true
+      '@libsql/client':
+        optional: true
+      '@libsql/client-wasm':
+        optional: true
+      '@neondatabase/serverless':
+        optional: true
+      '@op-engineering/op-sqlite':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@planetscale/database':
+        optional: true
+      '@prisma/client':
+        optional: true
+      '@tidbcloud/serverless':
+        optional: true
+      '@types/better-sqlite3':
+        optional: true
+      '@types/pg':
+        optional: true
+      '@types/sql.js':
+        optional: true
+      '@upstash/redis':
+        optional: true
+      '@vercel/postgres':
+        optional: true
+      '@xata.io/client':
+        optional: true
+      better-sqlite3:
+        optional: true
+      bun-types:
+        optional: true
+      expo-sqlite:
+        optional: true
+      gel:
+        optional: true
+      knex:
+        optional: true
+      kysely:
+        optional: true
+      mysql2:
+        optional: true
+      pg:
+        optional: true
+      postgres:
+        optional: true
+      prisma:
+        optional: true
+      sql.js:
+        optional: true
+      sqlite3:
+        optional: true
+
   error-stack-parser-es@1.0.5:
     resolution: {integrity: sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==}
 
   es-errors@1.3.0:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
+
+  esbuild@0.18.20:
+    resolution: {integrity: sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.25.12:
+    resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.27.2:
     resolution: {integrity: sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw==}
@@ -1554,6 +2003,10 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
 
@@ -1598,6 +2051,13 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+
+  get-tsconfig@4.14.0:
+    resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
     engines: {node: '>=10.13.0'}
@@ -1628,6 +2088,10 @@ packages:
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
     engines: {node: '>= 14'}
+
+  human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1666,8 +2130,15 @@ packages:
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
+  is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
+
+  jose@5.10.0:
+    resolution: {integrity: sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==}
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -1722,6 +2193,13 @@ packages:
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  merge-stream@2.0.0:
+    resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
+
+  mimic-fn@2.1.0:
+    resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
+    engines: {node: '>=6'}
 
   miniflare@4.20260317.1:
     resolution: {integrity: sha512-A3csI1HXEIfqe3oscgpoRMHdYlkReQKPH/g5JE53vFSjoM6YIAOGAzyDNeYffwd9oQkPWDj9xER8+vpxei8klA==}
@@ -1784,12 +2262,24 @@ packages:
     engines: {node: ^18.17.0 || >=20.5.0}
     hasBin: true
 
+  npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  onetime@5.1.2:
+    resolution: {integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==}
+    engines: {node: '>=6'}
 
   optionator@0.9.4:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
+
+  os-paths@4.4.0:
+    resolution: {integrity: sha512-wrAwOeXp1RRMFfQY8Sy7VaGVmPocaLwSFOYCGKSyo8qmJ+/yaafCl5BCA1IQZWqFSRBrKDYFeR9d/VyQzfH/jg==}
+    engines: {node: '>= 6.0'}
 
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
@@ -1823,6 +2313,40 @@ packages:
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pg-cloudflare@1.4.0:
+    resolution: {integrity: sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==}
+
+  pg-connection-string@2.14.0:
+    resolution: {integrity: sha512-XwWDGcLRGCXAR8F/AM5bG7Q+A3Wm2s6QeEjlOKZLlH3UYcguiqCWKyWXVag5TLTIjR7oOJUY8kcADaZgWPyLeg==}
+
+  pg-int8@1.0.1:
+    resolution: {integrity: sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==}
+    engines: {node: '>=4.0.0'}
+
+  pg-pool@3.14.0:
+    resolution: {integrity: sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==}
+    peerDependencies:
+      pg: '>=8.0'
+
+  pg-protocol@1.15.0:
+    resolution: {integrity: sha512-cq9sECI5s0+uPUXjbz8ioyPJni6RzsRib0US67i5IoTZKw8fNeYlVE7u8F4dG7vEJJtc5wdD1K189lCCUwqWTQ==}
+
+  pg-types@2.2.0:
+    resolution: {integrity: sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==}
+    engines: {node: '>=4'}
+
+  pg@8.22.0:
+    resolution: {integrity: sha512-8wih1vVIBMxoUM2oB4soJsD9tDnDpLv4OXBJ+EJzFsvycD+lfyIreC2gGHq78f8jbLLt+bvlPTFdFZfJkOuzAA==}
+    engines: {node: '>= 16.0.0'}
+    peerDependencies:
+      pg-native: '>=3.0.1'
+    peerDependenciesMeta:
+      pg-native:
+        optional: true
+
+  pgpass@1.0.5:
+    resolution: {integrity: sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -1869,6 +2393,22 @@ packages:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  postgres-array@2.0.0:
+    resolution: {integrity: sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==}
+    engines: {node: '>=4'}
+
+  postgres-bytea@1.0.1:
+    resolution: {integrity: sha512-5+5HqXnsZPE65IJZSMkZtURARZelel2oXUEO8rH83VS/hxH5vv1uHquPg5wZs8yMAfdv971IU+kcPUczi7NVBQ==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-date@1.0.7:
+    resolution: {integrity: sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==}
+    engines: {node: '>=0.10.0'}
+
+  postgres-interval@1.2.0:
+    resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
+    engines: {node: '>=0.10.0'}
+
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
@@ -1903,6 +2443,9 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -1943,6 +2486,9 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
+  signal-exit@3.0.7:
+    resolution: {integrity: sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==}
+
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
@@ -1950,6 +2496,21 @@ packages:
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
+
+  source-map-support@0.5.21:
+    resolution: {integrity: sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==}
+
+  source-map@0.6.1:
+    resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
+    engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
 
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
@@ -2011,6 +2572,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.23.0:
+    resolution: {integrity: sha512-eUdUIaCr963q2h5u3+QwvYp0+eqPvn+egeqZUm0hwERCqqx1E3kK5ehbGCvqSE5MQAULr67ww0cA3jKc3YkM1w==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -2138,6 +2704,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  xdg-app-paths@5.5.1:
+    resolution: {integrity: sha512-hI3flOB4PLZIy5prbtTpirobtPE2ZtZ52szO+2mM9Efp6ErM398La+C1lIpNWDfNoQk+6Lsi6nMcCwVB7pxeMQ==}
+    engines: {node: '>= 6.0'}
+
+  xdg-portable@7.3.0:
+    resolution: {integrity: sha512-sqMMuL1rc0FmMBOzCpd0yuy9trqF2yTTVe+E9ogwCSWQCdDEtQUwrZPT6AxqtsFGRNxycgncbP/xmOOSPw5ZUw==}
+    engines: {node: '>= 6.0'}
+
+  xtend@4.0.2:
+    resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
+    engines: {node: '>=0.4'}
+
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
@@ -2158,6 +2736,9 @@ packages:
 
   zimmerframe@1.1.4:
     resolution: {integrity: sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==}
+
+  zod@4.1.11:
+    resolution: {integrity: sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==}
 
 snapshots:
 
@@ -2190,9 +2771,24 @@ snapshots:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
 
+  '@drizzle-team/brocli@0.10.2': {}
+
   '@emnapi/runtime@1.9.1':
     dependencies:
       tslib: 2.8.1
+    optional: true
+
+  '@esbuild-kit/core-utils@3.3.2':
+    dependencies:
+      esbuild: 0.18.20
+      source-map-support: 0.5.21
+
+  '@esbuild-kit/esm-loader@2.6.5':
+    dependencies:
+      '@esbuild-kit/core-utils': 3.3.2
+      get-tsconfig: 4.14.0
+
+  '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
   '@esbuild/aix-ppc64@0.27.2':
@@ -2204,6 +2800,12 @@ snapshots:
   '@esbuild/aix-ppc64@0.28.1':
     optional: true
 
+  '@esbuild/android-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.12':
+    optional: true
+
   '@esbuild/android-arm64@0.27.2':
     optional: true
 
@@ -2211,6 +2813,12 @@ snapshots:
     optional: true
 
   '@esbuild/android-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/android-arm@0.18.20':
+    optional: true
+
+  '@esbuild/android-arm@0.25.12':
     optional: true
 
   '@esbuild/android-arm@0.27.2':
@@ -2222,6 +2830,12 @@ snapshots:
   '@esbuild/android-arm@0.28.1':
     optional: true
 
+  '@esbuild/android-x64@0.18.20':
+    optional: true
+
+  '@esbuild/android-x64@0.25.12':
+    optional: true
+
   '@esbuild/android-x64@0.27.2':
     optional: true
 
@@ -2229,6 +2843,12 @@ snapshots:
     optional: true
 
   '@esbuild/android-x64@0.28.1':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.2':
@@ -2240,6 +2860,12 @@ snapshots:
   '@esbuild/darwin-arm64@0.28.1':
     optional: true
 
+  '@esbuild/darwin-x64@0.18.20':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.2':
     optional: true
 
@@ -2247,6 +2873,12 @@ snapshots:
     optional: true
 
   '@esbuild/darwin-x64@0.28.1':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.2':
@@ -2258,6 +2890,12 @@ snapshots:
   '@esbuild/freebsd-arm64@0.28.1':
     optional: true
 
+  '@esbuild/freebsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.2':
     optional: true
 
@@ -2265,6 +2903,12 @@ snapshots:
     optional: true
 
   '@esbuild/freebsd-x64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.12':
     optional: true
 
   '@esbuild/linux-arm64@0.27.2':
@@ -2276,6 +2920,12 @@ snapshots:
   '@esbuild/linux-arm64@0.28.1':
     optional: true
 
+  '@esbuild/linux-arm@0.18.20':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.12':
+    optional: true
+
   '@esbuild/linux-arm@0.27.2':
     optional: true
 
@@ -2283,6 +2933,12 @@ snapshots:
     optional: true
 
   '@esbuild/linux-arm@0.28.1':
+    optional: true
+
+  '@esbuild/linux-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.12':
     optional: true
 
   '@esbuild/linux-ia32@0.27.2':
@@ -2294,6 +2950,12 @@ snapshots:
   '@esbuild/linux-ia32@0.28.1':
     optional: true
 
+  '@esbuild/linux-loong64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.2':
     optional: true
 
@@ -2301,6 +2963,12 @@ snapshots:
     optional: true
 
   '@esbuild/linux-loong64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.18.20':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.2':
@@ -2312,6 +2980,12 @@ snapshots:
   '@esbuild/linux-mips64el@0.28.1':
     optional: true
 
+  '@esbuild/linux-ppc64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.2':
     optional: true
 
@@ -2319,6 +2993,12 @@ snapshots:
     optional: true
 
   '@esbuild/linux-ppc64@0.28.1':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.2':
@@ -2330,6 +3010,12 @@ snapshots:
   '@esbuild/linux-riscv64@0.28.1':
     optional: true
 
+  '@esbuild/linux-s390x@0.18.20':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.2':
     optional: true
 
@@ -2337,6 +3023,12 @@ snapshots:
     optional: true
 
   '@esbuild/linux-s390x@0.28.1':
+    optional: true
+
+  '@esbuild/linux-x64@0.18.20':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.12':
     optional: true
 
   '@esbuild/linux-x64@0.27.2':
@@ -2348,6 +3040,9 @@ snapshots:
   '@esbuild/linux-x64@0.28.1':
     optional: true
 
+  '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.2':
     optional: true
 
@@ -2355,6 +3050,12 @@ snapshots:
     optional: true
 
   '@esbuild/netbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.2':
@@ -2366,6 +3067,9 @@ snapshots:
   '@esbuild/netbsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.2':
     optional: true
 
@@ -2373,6 +3077,12 @@ snapshots:
     optional: true
 
   '@esbuild/openbsd-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.18.20':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.2':
@@ -2384,6 +3094,9 @@ snapshots:
   '@esbuild/openbsd-x64@0.28.1':
     optional: true
 
+  '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.2':
     optional: true
 
@@ -2391,6 +3104,12 @@ snapshots:
     optional: true
 
   '@esbuild/openharmony-arm64@0.28.1':
+    optional: true
+
+  '@esbuild/sunos-x64@0.18.20':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.12':
     optional: true
 
   '@esbuild/sunos-x64@0.27.2':
@@ -2402,6 +3121,12 @@ snapshots:
   '@esbuild/sunos-x64@0.28.1':
     optional: true
 
+  '@esbuild/win32-arm64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.2':
     optional: true
 
@@ -2411,6 +3136,12 @@ snapshots:
   '@esbuild/win32-arm64@0.28.1':
     optional: true
 
+  '@esbuild/win32-ia32@0.18.20':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.12':
+    optional: true
+
   '@esbuild/win32-ia32@0.27.2':
     optional: true
 
@@ -2418,6 +3149,12 @@ snapshots:
     optional: true
 
   '@esbuild/win32-ia32@0.28.1':
+    optional: true
+
+  '@esbuild/win32-x64@0.18.20':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.12':
     optional: true
 
   '@esbuild/win32-x64@0.27.2':
@@ -2843,24 +3580,24 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-cloudflare@7.2.8(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)))(wrangler@4.76.0(@cloudflare/workers-types@4.20260317.1))':
+  '@sveltejs/adapter-cloudflare@7.2.8(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(wrangler@4.76.0(@cloudflare/workers-types@4.20260317.1))':
     dependencies:
       '@cloudflare/workers-types': 4.20260317.1
-      '@sveltejs/kit': 2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0))
+      '@sveltejs/kit': 2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0))
       worktop: 0.8.0-next.18
       wrangler: 4.76.0(@cloudflare/workers-types@4.20260317.1)
 
-  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)))':
+  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))':
     dependencies:
       '@rollup/plugin-commonjs': 29.0.2(rollup@4.60.2)
       '@rollup/plugin-json': 6.1.0(rollup@4.60.2)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.2)
-      '@sveltejs/kit': 2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0))
+      '@sveltejs/kit': 2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0))
       rollup: 4.60.2
 
-  '@sveltejs/adapter-vercel@6.3.4(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)))(rollup@4.60.2)':
+  '@sveltejs/adapter-vercel@6.3.4(@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(rollup@4.60.2)':
     dependencies:
-      '@sveltejs/kit': 2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0))
+      '@sveltejs/kit': 2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0))
       '@vercel/nft': 1.10.2(rollup@4.60.2)
       esbuild: 0.28.1
     transitivePeerDependencies:
@@ -2868,11 +3605,11 @@ snapshots:
       - rollup
       - supports-color
 
-  '@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0))':
+  '@sveltejs/kit@2.50.2(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(svelte@5.50.0)(typescript@5.9.3)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0))':
     dependencies:
       '@standard-schema/spec': 1.0.0
       '@sveltejs/acorn-typescript': 1.0.6(acorn@8.15.0)
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
@@ -2885,28 +3622,28 @@ snapshots:
       set-cookie-parser: 3.0.1
       sirv: 3.0.2
       svelte: 5.50.0
-      vite: 7.3.1(@types/node@24.1.0)
+      vite: 7.3.1(@types/node@24.1.0)(tsx@4.23.0)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@5.0.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)))(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0))':
+  '@sveltejs/vite-plugin-svelte-inspector@5.0.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0))
+      '@sveltejs/vite-plugin-svelte': 6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0))
       debug: 4.4.3
       svelte: 5.50.0
-      vite: 7.3.1(@types/node@24.1.0)
+      vite: 7.3.1(@types/node@24.1.0)(tsx@4.23.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0))':
+  '@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 5.0.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)))(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0))
+      '@sveltejs/vite-plugin-svelte-inspector': 5.0.1(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)))(svelte@5.50.0)(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0))
       deepmerge: 4.3.1
       magic-string: 0.30.21
       obug: 2.1.1
       svelte: 5.50.0
-      vite: 7.3.1(@types/node@24.1.0)
-      vitefu: 1.1.1(vite@7.3.1(@types/node@24.1.0))
+      vite: 7.3.1(@types/node@24.1.0)(tsx@4.23.0)
+      vitefu: 1.1.1(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0))
     transitivePeerDependencies:
       - supports-color
 
@@ -2919,7 +3656,12 @@ snapshots:
   '@types/node@24.1.0':
     dependencies:
       undici-types: 7.8.0
-    optional: true
+
+  '@types/pg@8.20.0':
+    dependencies:
+      '@types/node': 24.1.0
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
 
   '@types/resolve@1.20.2': {}
 
@@ -3014,6 +3756,21 @@ snapshots:
       '@typescript-eslint/types': 8.54.0
       eslint-visitor-keys: 4.2.1
 
+  '@vercel/cli-config@0.2.0':
+    dependencies:
+      xdg-app-paths: 5.5.1
+      zod: 4.1.11
+
+  '@vercel/cli-exec@1.0.0':
+    dependencies:
+      execa: 5.1.1
+
+  '@vercel/functions@3.7.5(ws@8.18.0)':
+    dependencies:
+      '@vercel/oidc': 3.8.0
+    optionalDependencies:
+      ws: 8.18.0
+
   '@vercel/nft@1.10.2(rollup@4.60.2)':
     dependencies:
       '@mapbox/node-pre-gyp': 2.0.3
@@ -3032,6 +3789,12 @@ snapshots:
       - encoding
       - rollup
       - supports-color
+
+  '@vercel/oidc@3.8.0':
+    dependencies:
+      '@vercel/cli-config': 0.2.0
+      '@vercel/cli-exec': 1.0.0
+      jose: 5.10.0
 
   abbrev@3.0.1: {}
 
@@ -3089,6 +3852,8 @@ snapshots:
     dependencies:
       balanced-match: 4.0.4
 
+  buffer-from@1.1.2: {}
+
   callsites@3.1.0: {}
 
   chalk@4.1.2:
@@ -3140,9 +3905,76 @@ snapshots:
 
   devalue@5.6.2: {}
 
+  drizzle-kit@0.31.10:
+    dependencies:
+      '@drizzle-team/brocli': 0.10.2
+      '@esbuild-kit/esm-loader': 2.6.5
+      esbuild: 0.25.12
+      tsx: 4.23.0
+
+  drizzle-orm@0.45.2(@cloudflare/workers-types@4.20260317.1)(@types/pg@8.20.0)(pg@8.22.0):
+    optionalDependencies:
+      '@cloudflare/workers-types': 4.20260317.1
+      '@types/pg': 8.20.0
+      pg: 8.22.0
+
   error-stack-parser-es@1.0.5: {}
 
   es-errors@1.3.0: {}
+
+  esbuild@0.18.20:
+    optionalDependencies:
+      '@esbuild/android-arm': 0.18.20
+      '@esbuild/android-arm64': 0.18.20
+      '@esbuild/android-x64': 0.18.20
+      '@esbuild/darwin-arm64': 0.18.20
+      '@esbuild/darwin-x64': 0.18.20
+      '@esbuild/freebsd-arm64': 0.18.20
+      '@esbuild/freebsd-x64': 0.18.20
+      '@esbuild/linux-arm': 0.18.20
+      '@esbuild/linux-arm64': 0.18.20
+      '@esbuild/linux-ia32': 0.18.20
+      '@esbuild/linux-loong64': 0.18.20
+      '@esbuild/linux-mips64el': 0.18.20
+      '@esbuild/linux-ppc64': 0.18.20
+      '@esbuild/linux-riscv64': 0.18.20
+      '@esbuild/linux-s390x': 0.18.20
+      '@esbuild/linux-x64': 0.18.20
+      '@esbuild/netbsd-x64': 0.18.20
+      '@esbuild/openbsd-x64': 0.18.20
+      '@esbuild/sunos-x64': 0.18.20
+      '@esbuild/win32-arm64': 0.18.20
+      '@esbuild/win32-ia32': 0.18.20
+      '@esbuild/win32-x64': 0.18.20
+
+  esbuild@0.25.12:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.12
+      '@esbuild/android-arm': 0.25.12
+      '@esbuild/android-arm64': 0.25.12
+      '@esbuild/android-x64': 0.25.12
+      '@esbuild/darwin-arm64': 0.25.12
+      '@esbuild/darwin-x64': 0.25.12
+      '@esbuild/freebsd-arm64': 0.25.12
+      '@esbuild/freebsd-x64': 0.25.12
+      '@esbuild/linux-arm': 0.25.12
+      '@esbuild/linux-arm64': 0.25.12
+      '@esbuild/linux-ia32': 0.25.12
+      '@esbuild/linux-loong64': 0.25.12
+      '@esbuild/linux-mips64el': 0.25.12
+      '@esbuild/linux-ppc64': 0.25.12
+      '@esbuild/linux-riscv64': 0.25.12
+      '@esbuild/linux-s390x': 0.25.12
+      '@esbuild/linux-x64': 0.25.12
+      '@esbuild/netbsd-arm64': 0.25.12
+      '@esbuild/netbsd-x64': 0.25.12
+      '@esbuild/openbsd-arm64': 0.25.12
+      '@esbuild/openbsd-x64': 0.25.12
+      '@esbuild/openharmony-arm64': 0.25.12
+      '@esbuild/sunos-x64': 0.25.12
+      '@esbuild/win32-arm64': 0.25.12
+      '@esbuild/win32-ia32': 0.25.12
+      '@esbuild/win32-x64': 0.25.12
 
   esbuild@0.27.2:
     optionalDependencies:
@@ -3329,6 +4161,18 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  execa@5.1.1:
+    dependencies:
+      cross-spawn: 7.0.6
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+
   fast-deep-equal@3.1.3: {}
 
   fast-json-stable-stringify@2.1.0: {}
@@ -3362,6 +4206,12 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  get-stream@6.0.1: {}
+
+  get-tsconfig@4.14.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -3390,6 +4240,8 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
+
+  human-signals@2.1.0: {}
 
   ignore@5.3.2: {}
 
@@ -3422,7 +4274,11 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  is-stream@2.0.1: {}
+
   isexe@2.0.0: {}
+
+  jose@5.10.0: {}
 
   js-yaml@4.1.0:
     dependencies:
@@ -3466,6 +4322,10 @@ snapshots:
   magic-string@0.30.21:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  merge-stream@2.0.0: {}
+
+  mimic-fn@2.1.0: {}
 
   miniflare@4.20260317.1:
     dependencies:
@@ -3517,7 +4377,15 @@ snapshots:
     dependencies:
       abbrev: 3.0.1
 
+  npm-run-path@4.0.1:
+    dependencies:
+      path-key: 3.1.1
+
   obug@2.1.1: {}
+
+  onetime@5.1.2:
+    dependencies:
+      mimic-fn: 2.1.0
 
   optionator@0.9.4:
     dependencies:
@@ -3527,6 +4395,8 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
       word-wrap: 1.2.5
+
+  os-paths@4.4.0: {}
 
   p-limit@3.1.0:
     dependencies:
@@ -3554,6 +4424,41 @@ snapshots:
   path-to-regexp@6.3.0: {}
 
   pathe@2.0.3: {}
+
+  pg-cloudflare@1.4.0:
+    optional: true
+
+  pg-connection-string@2.14.0: {}
+
+  pg-int8@1.0.1: {}
+
+  pg-pool@3.14.0(pg@8.22.0):
+    dependencies:
+      pg: 8.22.0
+
+  pg-protocol@1.15.0: {}
+
+  pg-types@2.2.0:
+    dependencies:
+      pg-int8: 1.0.1
+      postgres-array: 2.0.0
+      postgres-bytea: 1.0.1
+      postgres-date: 1.0.7
+      postgres-interval: 1.2.0
+
+  pg@8.22.0:
+    dependencies:
+      pg-connection-string: 2.14.0
+      pg-pool: 3.14.0(pg@8.22.0)
+      pg-protocol: 1.15.0
+      pg-types: 2.2.0
+      pgpass: 1.0.5
+    optionalDependencies:
+      pg-cloudflare: 1.4.0
+
+  pgpass@1.0.5:
+    dependencies:
+      split2: 4.2.0
 
   picocolors@1.1.1: {}
 
@@ -3587,6 +4492,16 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  postgres-array@2.0.0: {}
+
+  postgres-bytea@1.0.1: {}
+
+  postgres-date@1.0.7: {}
+
+  postgres-interval@1.2.0:
+    dependencies:
+      xtend: 4.0.2
+
   prelude-ls@1.2.1: {}
 
   prettier-plugin-svelte@3.4.1(prettier@3.8.1)(svelte@5.50.0):
@@ -3605,6 +4520,8 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
+
+  resolve-pkg-maps@1.0.0: {}
 
   resolve@1.22.12:
     dependencies:
@@ -3717,6 +4634,8 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  signal-exit@3.0.7: {}
+
   sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
@@ -3724,6 +4643,17 @@ snapshots:
       totalist: 3.0.1
 
   source-map-js@1.2.1: {}
+
+  source-map-support@0.5.21:
+    dependencies:
+      buffer-from: 1.1.2
+      source-map: 0.6.1
+
+  source-map@0.6.1: {}
+
+  split2@4.2.0: {}
+
+  strip-final-newline@2.0.0: {}
 
   strip-json-comments@3.1.1: {}
 
@@ -3800,6 +4730,12 @@ snapshots:
   tslib@2.8.1:
     optional: true
 
+  tsx@4.23.0:
+    dependencies:
+      esbuild: 0.28.1
+    optionalDependencies:
+      fsevents: 2.3.3
+
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
@@ -3817,8 +4753,7 @@ snapshots:
 
   typescript@5.9.3: {}
 
-  undici-types@7.8.0:
-    optional: true
+  undici-types@7.8.0: {}
 
   undici@7.24.4: {}
 
@@ -3832,7 +4767,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  vite@7.3.1(@types/node@24.1.0):
+  vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0):
     dependencies:
       esbuild: 0.27.2
       fdir: 6.5.0(picomatch@4.0.3)
@@ -3843,10 +4778,11 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.1.0
       fsevents: 2.3.3
+      tsx: 4.23.0
 
-  vitefu@1.1.1(vite@7.3.1(@types/node@24.1.0)):
+  vitefu@1.1.1(vite@7.3.1(@types/node@24.1.0)(tsx@4.23.0)):
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.1.0)
+      vite: 7.3.1(@types/node@24.1.0)(tsx@4.23.0)
 
   webidl-conversions@3.0.1: {}
 
@@ -3893,6 +4829,17 @@ snapshots:
 
   ws@8.18.0: {}
 
+  xdg-app-paths@5.5.1:
+    dependencies:
+      os-paths: 4.4.0
+      xdg-portable: 7.3.0
+
+  xdg-portable@7.3.0:
+    dependencies:
+      os-paths: 4.4.0
+
+  xtend@4.0.2: {}
+
   yallist@5.0.0: {}
 
   yaml@1.10.2: {}
@@ -3913,3 +4860,5 @@ snapshots:
       youch-core: 0.3.3
 
   zimmerframe@1.1.4: {}
+
+  zod@4.1.11: {}

--- a/web/src/lib/components/CollapsibleStatsSection.svelte
+++ b/web/src/lib/components/CollapsibleStatsSection.svelte
@@ -1,0 +1,106 @@
+<script lang="ts">
+	import { ChevronDown } from 'lucide-svelte';
+	import type { Snippet } from 'svelte';
+	import { slide } from 'svelte/transition';
+
+	type StatRow = { label: string; value: string };
+
+	let {
+		title,
+		rows,
+		marginTop,
+		children
+	}: {
+		title: string;
+		rows: StatRow[];
+		marginTop: string;
+		children?: Snippet;
+	} = $props();
+
+	let open = $state(false);
+</script>
+
+<section style:margin-top={marginTop}>
+	<button class="toggle" onclick={() => (open = !open)} aria-expanded={open} type="button">
+		<span>{title}</span>
+		<ChevronDown size={14} class="chev {open ? 'open' : ''}" />
+	</button>
+
+	{#if open}
+		<div transition:slide={{ duration: 200 }}>
+			<dl class="stats">
+				{#each rows as row (row.label)}
+					<div class="row">
+						<dt>{row.label}</dt>
+						<dd>{row.value}</dd>
+					</div>
+				{/each}
+			</dl>
+
+			{#if children}
+				{@render children()}
+			{/if}
+		</div>
+	{/if}
+</section>
+
+<style>
+	.toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 5px;
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+		color: var(--text-muted);
+		font-family: inherit;
+		font-size: 0.8125rem;
+	}
+
+	.toggle :global(.chev) {
+		transition: transform 0.2s ease;
+	}
+
+	.toggle :global(.chev.open) {
+		transform: rotate(180deg);
+	}
+
+	@media (hover: hover) and (pointer: fine) {
+		.toggle:hover {
+			color: var(--text-secondary);
+		}
+	}
+
+	.stats {
+		margin: 1.25rem 0 0 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		max-width: 260px;
+	}
+
+	.row {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: 1.5rem;
+		font-size: 0.8125rem;
+	}
+
+	dt {
+		color: var(--text-muted);
+	}
+
+	dd {
+		margin: 0;
+		color: var(--text-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.toggle :global(.chev) {
+			transition: none;
+		}
+	}
+</style>

--- a/web/src/lib/components/ContributionGraph.svelte
+++ b/web/src/lib/components/ContributionGraph.svelte
@@ -1,0 +1,146 @@
+<script lang="ts">
+	import type { ContributionDay } from '$lib/github';
+	import { DITHER_GREEN, paintCell, type Rgb } from '$lib/dither/paint';
+	import { formatDay } from '$lib/format';
+
+	let { weeks, color = DITHER_GREEN }: { weeks: ContributionDay[][]; color?: Rgb } = $props();
+
+	// Backing-canvas geometry: each day is a CELL_PX square with a GAP_PX gutter, laid out as
+	// columns (weeks) × 7 rows (weekdays). The canvas is drawn at this native resolution and CSS-scaled
+	// to fill the container, so the dither dots stay chunky (image-rendering: pixelated).
+	const CELL_PX = 4;
+	const GAP_PX = 1;
+	const ROWS = 7;
+	const STRIDE = CELL_PX + GAP_PX;
+	const gridH = ROWS * STRIDE - GAP_PX;
+
+	const cols = $derived(weeks.length);
+	const gridW = $derived(Math.max(1, cols * STRIDE - GAP_PX));
+
+	let canvas: HTMLCanvasElement;
+	let wrapper: HTMLDivElement;
+	let width = $state(0);
+	let hoverWeek = $state<number | null>(null);
+	let hoverDay = $state<number | null>(null);
+	let pointerX = $state(0);
+
+	// GitHub rows are Sunday-first; getUTCDay() matches (0 = Sunday). Placing by weekday keeps rows
+	// aligned even for the partial first/last weeks GitHub returns.
+	const weekdayOf = (date: string) => new Date(`${date}T00:00:00Z`).getUTCDay();
+
+	function render() {
+		if (!canvas) return;
+		canvas.width = gridW;
+		canvas.height = gridH;
+		const ctx = canvas.getContext('2d');
+		if (!ctx) return;
+		ctx.clearRect(0, 0, gridW, gridH);
+
+		weeks.forEach((week, wi) => {
+			const x0 = wi * STRIDE;
+			for (const day of week) {
+				const wd = weekdayOf(day.date);
+				const y0 = wd * STRIDE;
+				const active = wi === hoverWeek && wd === hoverDay ? 1 : 0;
+				paintCell(ctx, x0, y0, CELL_PX, color, day.level / 4, active);
+			}
+		});
+	}
+
+	function onMove(e: PointerEvent) {
+		const rect = canvas.getBoundingClientRect();
+		pointerX = e.clientX - rect.left;
+		const relX = pointerX / rect.width;
+		const relY = (e.clientY - rect.top) / rect.height;
+		hoverWeek = Math.min(cols - 1, Math.max(0, Math.floor((relX * gridW) / STRIDE)));
+		hoverDay = Math.min(ROWS - 1, Math.max(0, Math.floor((relY * gridH) / STRIDE)));
+	}
+
+	function clearHover() {
+		hoverWeek = null;
+		hoverDay = null;
+	}
+
+	const active = $derived(
+		hoverWeek != null && hoverDay != null
+			? (weeks[hoverWeek]?.find((d) => weekdayOf(d.date) === hoverDay) ?? null)
+			: null
+	);
+	// Keep the tooltip inside the wrapper.
+	const tipLeft = $derived(Math.max(8, Math.min(Math.max(8, width - 8), pointerX)));
+
+	$effect(() => {
+		// render() reads weeks, color, gridW, hoverWeek, hoverDay — tracked, so this re-runs on hover.
+		render();
+	});
+
+	$effect(() => {
+		if (!wrapper) return;
+		const ro = new ResizeObserver((entries) => {
+			width = entries[0].contentRect.width;
+		});
+		ro.observe(wrapper);
+		return () => ro.disconnect();
+	});
+</script>
+
+<div class="graph" bind:this={wrapper}>
+	<canvas bind:this={canvas} onpointermove={onMove} onpointerleave={clearHover}></canvas>
+
+	{#if active}
+		<div class="tip" style="left: {tipLeft}px" class:flip={tipLeft > width / 2}>
+			<span class="tip-count">
+				{active.count === 0 ? 'No' : active.count.toLocaleString('en-US')}
+				{active.count === 1 ? 'contribution' : 'contributions'}
+			</span>
+			<span class="tip-date">{formatDay(active.date)}</span>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.graph {
+		position: relative;
+		width: 100%;
+	}
+
+	canvas {
+		display: block;
+		width: 100%;
+		height: auto;
+		image-rendering: pixelated;
+		cursor: crosshair;
+	}
+
+	.tip {
+		position: absolute;
+		bottom: calc(100% + 8px);
+		transform: translateX(-8px);
+		min-width: 150px;
+		padding: 0.5rem 0.65rem;
+		display: flex;
+		flex-direction: column;
+		gap: 0.15rem;
+		background: #1c1c1f;
+		border: 1px solid #2c2c30;
+		border-radius: 10px;
+		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+		pointer-events: none;
+		z-index: 2;
+	}
+
+	.tip.flip {
+		transform: translateX(calc(-100% + 8px));
+	}
+
+	.tip-count {
+		color: #f4f4f5;
+		font-weight: 600;
+		font-size: 0.875rem;
+	}
+
+	.tip-date {
+		color: #8a8a90;
+		font-size: 0.75rem;
+	}
+</style>

--- a/web/src/lib/components/ContributionGraph.svelte
+++ b/web/src/lib/components/ContributionGraph.svelte
@@ -5,9 +5,7 @@
 
 	let { weeks, color = DITHER_GREEN }: { weeks: ContributionDay[][]; color?: Rgb } = $props();
 
-	// Backing-canvas geometry: each day is a CELL_PX square with a GAP_PX gutter, laid out as
-	// columns (weeks) × 7 rows (weekdays). The canvas is drawn at this native resolution and CSS-scaled
-	// to fill the container, so the dither dots stay chunky (image-rendering: pixelated).
+	// Draw at native dither resolution and let CSS scale the canvas.
 	const CELL_PX = 4;
 	const GAP_PX = 1;
 	const ROWS = 7;
@@ -24,27 +22,32 @@
 	let hoverDay = $state<number | null>(null);
 	let pointerX = $state(0);
 
-	// GitHub rows are Sunday-first; getUTCDay() matches (0 = Sunday). Placing by weekday keeps rows
-	// aligned even for the partial first/last weeks GitHub returns.
+	// GitHub weeks and getUTCDay() are both Sunday-first.
 	const weekdayOf = (date: string) => new Date(`${date}T00:00:00Z`).getUTCDay();
 
-	function render() {
+	let ctx: CanvasRenderingContext2D | null = null;
+	let lastHover: { wi: number; day: ContributionDay } | null = null;
+
+	function paintDay(wi: number, day: ContributionDay, intensity: number) {
+		if (!ctx) return;
+		const x0 = wi * STRIDE;
+		const y0 = weekdayOf(day.date) * STRIDE;
+		// Clear first because paintCell uses partial alpha.
+		ctx.clearRect(x0, y0, CELL_PX, CELL_PX);
+		paintCell(ctx, x0, y0, CELL_PX, color, day.level / 4, intensity);
+	}
+
+	function renderBase() {
 		if (!canvas) return;
 		canvas.width = gridW;
 		canvas.height = gridH;
-		const ctx = canvas.getContext('2d');
+		ctx = canvas.getContext('2d');
 		if (!ctx) return;
 		ctx.clearRect(0, 0, gridW, gridH);
-
 		weeks.forEach((week, wi) => {
-			const x0 = wi * STRIDE;
-			for (const day of week) {
-				const wd = weekdayOf(day.date);
-				const y0 = wd * STRIDE;
-				const active = wi === hoverWeek && wd === hoverDay ? 1 : 0;
-				paintCell(ctx, x0, y0, CELL_PX, color, day.level / 4, active);
-			}
+			for (const day of week) paintDay(wi, day, 0);
 		});
+		lastHover = null;
 	}
 
 	function onMove(e: PointerEvent) {
@@ -66,12 +69,25 @@
 			? (weeks[hoverWeek]?.find((d) => weekdayOf(d.date) === hoverDay) ?? null)
 			: null
 	);
-	// Keep the tooltip inside the wrapper.
 	const tipLeft = $derived(Math.max(8, Math.min(Math.max(8, width - 8), pointerX)));
 
 	$effect(() => {
-		// render() reads weeks, color, gridW, hoverWeek, hoverDay — tracked, so this re-runs on hover.
-		render();
+		renderBase();
+	});
+
+	$effect(() => {
+		const hw = hoverWeek;
+		const hd = hoverDay;
+		if (!ctx) return;
+		if (lastHover) paintDay(lastHover.wi, lastHover.day, 0);
+		lastHover = null;
+		if (hw != null && hd != null) {
+			const day = weeks[hw]?.find((d) => weekdayOf(d.date) === hd);
+			if (day) {
+				paintDay(hw, day, 1);
+				lastHover = { wi: hw, day };
+			}
+		}
 	});
 
 	$effect(() => {
@@ -121,10 +137,10 @@
 		display: flex;
 		flex-direction: column;
 		gap: 0.15rem;
-		background: #1c1c1f;
-		border: 1px solid #2c2c30;
+		background: var(--surface);
+		border: 1px solid var(--surface-border);
 		border-radius: 10px;
-		box-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
+		box-shadow: var(--surface-shadow);
 		pointer-events: none;
 		z-index: 2;
 	}
@@ -134,13 +150,13 @@
 	}
 
 	.tip-count {
-		color: #f4f4f5;
+		color: var(--text-primary);
 		font-weight: 600;
 		font-size: 0.875rem;
 	}
 
 	.tip-date {
-		color: #8a8a90;
+		color: var(--text-muted);
 		font-size: 0.75rem;
 	}
 </style>

--- a/web/src/lib/components/ContributionSection.svelte
+++ b/web/src/lib/components/ContributionSection.svelte
@@ -2,12 +2,10 @@
 	import type { ContributionStats } from '$lib/github';
 	import { formatDay } from '$lib/format';
 	import { DITHER_GREEN, paintCell } from '$lib/dither/paint';
+	import CollapsibleStatsSection from './CollapsibleStatsSection.svelte';
 	import ContributionGraph from './ContributionGraph.svelte';
-	import { ChevronDown } from 'lucide-svelte';
-	import { slide } from 'svelte/transition';
 
 	let { stats }: { stats: ContributionStats } = $props();
-	let open = $state(false);
 
 	const rows = $derived([
 		{ label: 'contributions', value: stats.total.toLocaleString('en-US') },
@@ -24,7 +22,6 @@
 			: [])
 	]);
 
-	// The "less → more" legend, painted with the same dither engine as the grid so the tiers match.
 	let legendCanvas = $state<HTMLCanvasElement>();
 	$effect(() => {
 		if (!legendCanvas) return;
@@ -42,95 +39,20 @@
 	});
 </script>
 
-<section class="contrib">
-	<button class="toggle" onclick={() => (open = !open)} aria-expanded={open} type="button">
-		<span>github activity</span>
-		<ChevronDown size={14} class="chev {open ? 'open' : ''}" />
-	</button>
-
-	{#if open}
-		<div class="panel" transition:slide={{ duration: 200 }}>
-			<dl class="stats">
-				{#each rows as row (row.label)}
-					<div class="row">
-						<dt>{row.label}</dt>
-						<dd>{row.value}</dd>
-					</div>
-				{/each}
-			</dl>
-
-			{#if stats.weeks.length}
-				<div class="graph-wrap">
-					<ContributionGraph weeks={stats.weeks} />
-				</div>
-				<div class="legend">
-					<span>less</span>
-					<canvas bind:this={legendCanvas}></canvas>
-					<span>more</span>
-				</div>
-			{/if}
+<CollapsibleStatsSection title="github activity" {rows} marginTop="1.5rem">
+	{#if stats.weeks.length}
+		<div class="graph-wrap">
+			<ContributionGraph weeks={stats.weeks} />
+		</div>
+		<div class="legend">
+			<span>less</span>
+			<canvas bind:this={legendCanvas}></canvas>
+			<span>more</span>
 		</div>
 	{/if}
-</section>
+</CollapsibleStatsSection>
 
 <style>
-	.contrib {
-		margin-top: 1.5rem;
-	}
-
-	.toggle {
-		display: inline-flex;
-		align-items: center;
-		gap: 5px;
-		background: none;
-		border: none;
-		padding: 0;
-		cursor: pointer;
-		color: var(--text-muted);
-		font-family: inherit;
-		font-size: 0.8125rem;
-	}
-
-	.toggle :global(.chev) {
-		transition: transform 0.2s ease;
-	}
-
-	.toggle :global(.chev.open) {
-		transform: rotate(180deg);
-	}
-
-	@media (hover: hover) and (pointer: fine) {
-		.toggle:hover {
-			color: var(--text-secondary);
-		}
-	}
-
-	.stats {
-		margin: 1.25rem 0 0 0;
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-		max-width: 260px;
-	}
-
-	.row {
-		display: flex;
-		justify-content: space-between;
-		align-items: baseline;
-		gap: 1.5rem;
-		font-size: 0.8125rem;
-	}
-
-	dt {
-		color: var(--text-muted);
-	}
-
-	dd {
-		margin: 0;
-		color: var(--text-primary);
-		font-variant-numeric: tabular-nums;
-	}
-
 	.graph-wrap {
 		margin-top: 1.5rem;
 	}
@@ -148,11 +70,5 @@
 		height: 10px;
 		width: auto;
 		image-rendering: pixelated;
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.toggle :global(.chev) {
-			transition: none;
-		}
 	}
 </style>

--- a/web/src/lib/components/ContributionSection.svelte
+++ b/web/src/lib/components/ContributionSection.svelte
@@ -1,0 +1,158 @@
+<script lang="ts">
+	import type { ContributionStats } from '$lib/github';
+	import { formatDay } from '$lib/format';
+	import { DITHER_GREEN, paintCell } from '$lib/dither/paint';
+	import ContributionGraph from './ContributionGraph.svelte';
+	import { ChevronDown } from 'lucide-svelte';
+	import { slide } from 'svelte/transition';
+
+	let { stats }: { stats: ContributionStats } = $props();
+	let open = $state(false);
+
+	const rows = $derived([
+		{ label: 'contributions', value: stats.total.toLocaleString('en-US') },
+		{ label: 'active days', value: String(stats.activeDays) },
+		{ label: 'longest streak', value: `${stats.longestStreak}d` },
+		{ label: 'current streak', value: `${stats.currentStreak}d` },
+		...(stats.busiestDay
+			? [
+					{
+						label: 'busiest day',
+						value: `${stats.busiestDay.count} · ${formatDay(stats.busiestDay.date)}`
+					}
+				]
+			: [])
+	]);
+
+	// The "less → more" legend, painted with the same dither engine as the grid so the tiers match.
+	let legendCanvas = $state<HTMLCanvasElement>();
+	$effect(() => {
+		if (!legendCanvas) return;
+		const size = 4;
+		const gap = 1;
+		const n = 5;
+		legendCanvas.width = n * (size + gap) - gap;
+		legendCanvas.height = size;
+		const ctx = legendCanvas.getContext('2d');
+		if (!ctx) return;
+		ctx.clearRect(0, 0, legendCanvas.width, legendCanvas.height);
+		for (let i = 0; i < n; i++) {
+			paintCell(ctx, i * (size + gap), 0, size, DITHER_GREEN, i / (n - 1), 0);
+		}
+	});
+</script>
+
+<section class="contrib">
+	<button class="toggle" onclick={() => (open = !open)} aria-expanded={open} type="button">
+		<span>github activity</span>
+		<ChevronDown size={14} class="chev {open ? 'open' : ''}" />
+	</button>
+
+	{#if open}
+		<div class="panel" transition:slide={{ duration: 200 }}>
+			<dl class="stats">
+				{#each rows as row (row.label)}
+					<div class="row">
+						<dt>{row.label}</dt>
+						<dd>{row.value}</dd>
+					</div>
+				{/each}
+			</dl>
+
+			{#if stats.weeks.length}
+				<div class="graph-wrap">
+					<ContributionGraph weeks={stats.weeks} />
+				</div>
+				<div class="legend">
+					<span>less</span>
+					<canvas bind:this={legendCanvas}></canvas>
+					<span>more</span>
+				</div>
+			{/if}
+		</div>
+	{/if}
+</section>
+
+<style>
+	.contrib {
+		margin-top: 1.5rem;
+	}
+
+	.toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 5px;
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+		color: var(--text-muted);
+		font-family: inherit;
+		font-size: 0.8125rem;
+	}
+
+	.toggle :global(.chev) {
+		transition: transform 0.2s ease;
+	}
+
+	.toggle :global(.chev.open) {
+		transform: rotate(180deg);
+	}
+
+	@media (hover: hover) and (pointer: fine) {
+		.toggle:hover {
+			color: var(--text-secondary);
+		}
+	}
+
+	.stats {
+		margin: 1.25rem 0 0 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		max-width: 260px;
+	}
+
+	.row {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: 1.5rem;
+		font-size: 0.8125rem;
+	}
+
+	dt {
+		color: var(--text-muted);
+	}
+
+	dd {
+		margin: 0;
+		color: var(--text-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.graph-wrap {
+		margin-top: 1.5rem;
+	}
+
+	.legend {
+		display: flex;
+		align-items: center;
+		gap: 0.4rem;
+		margin-top: 0.65rem;
+		font-size: 0.6875rem;
+		color: var(--text-muted);
+	}
+
+	.legend canvas {
+		height: 10px;
+		width: auto;
+		image-rendering: pixelated;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.toggle :global(.chev) {
+			transition: none;
+		}
+	}
+</style>

--- a/web/src/lib/components/LinkPreview.svelte
+++ b/web/src/lib/components/LinkPreview.svelte
@@ -73,8 +73,8 @@
 	on:mouseenter={enter}
 	on:mouseleave={leave}
 	on:focus={enter}
-	on:blur={leave}
-><slot /></a>
+	on:blur={leave}><slot /></a
+>
 
 {#if mounted}
 	<span
@@ -86,12 +86,7 @@
 	>
 		{#if interacted}
 			<span class="skeleton" class:hidden={loaded}></span>
-			<img
-				class:loaded
-				src={previewUrl}
-				alt=""
-				on:load={() => (loaded = true)}
-			/>
+			<img class:loaded src={previewUrl} alt="" on:load={() => (loaded = true)} />
 		{/if}
 	</span>
 {/if}
@@ -160,9 +155,13 @@
 				transparent 100%
 			),
 			color-mix(in srgb, var(--text-primary) 7%, transparent);
-		background-size: 200% 100%, 100% 100%;
+		background-size:
+			200% 100%,
+			100% 100%;
 		background-repeat: no-repeat;
-		background-position: -50% 0, 0 0;
+		background-position:
+			-50% 0,
+			0 0;
 		animation: skeleton-shimmer 1.2s linear infinite;
 		transition: opacity 200ms var(--ease-out);
 	}
@@ -173,10 +172,14 @@
 
 	@keyframes skeleton-shimmer {
 		from {
-			background-position: -50% 0, 0 0;
+			background-position:
+				-50% 0,
+				0 0;
 		}
 		to {
-			background-position: 150% 0, 0 0;
+			background-position:
+				150% 0,
+				0 0;
 		}
 	}
 

--- a/web/src/lib/components/UsageChart.svelte
+++ b/web/src/lib/components/UsageChart.svelte
@@ -1,0 +1,181 @@
+<script lang="ts">
+	import type { DailyUsage } from '$lib/usage';
+	import { CELL, DITHER_PURPLE, paintBar, type Rgb } from '$lib/dither/paint';
+	import { formatDay, formatTokens, prettyModel } from '$lib/format';
+
+	let {
+		daily,
+		color = DITHER_PURPLE,
+		height = 150,
+		maxDays = 90
+	}: { daily: DailyUsage[]; color?: Rgb; height?: number; maxDays?: number } = $props();
+
+	// Newest `maxDays` days that had usage, oldest → newest so the chart reads left-to-right.
+	const data = $derived(daily.slice(-maxDays));
+	const max = $derived(Math.max(1, ...data.map((d) => d.tokens)));
+
+	let canvas: HTMLCanvasElement;
+	let wrapper: HTMLDivElement;
+	let width = $state(0);
+	let hover = $state<number | null>(null);
+	let pointerX = $state(0);
+
+	// Backing-canvas bar slots, so hover maths and drawing agree on where each bar sits.
+	function layout(cols: number) {
+		const n = Math.max(1, data.length);
+		const slot = cols / n;
+		const barW = Math.max(1, Math.round(slot * 0.68));
+		return { n, slot, barW };
+	}
+
+	function render() {
+		if (!canvas || !width) return;
+		const cols = Math.max(8, Math.round(width / CELL));
+		const rows = Math.max(8, Math.round(height / CELL));
+		canvas.width = cols;
+		canvas.height = rows;
+		const ctx = canvas.getContext('2d');
+		if (!ctx) return;
+		ctx.clearRect(0, 0, cols, rows);
+
+		const { slot, barW } = layout(cols);
+		data.forEach((d, i) => {
+			const x0 = Math.round(i * slot + (slot - barW) / 2);
+			// sqrt keeps quiet days visible next to a spike without lying about the ordering.
+			const h = Math.round(Math.sqrt(d.tokens / max) * (rows - 2));
+			const top = rows - h;
+			const intensity = i === hover ? 1 : 0;
+			for (let x = x0; x < x0 + barW && x < cols; x++) {
+				paintBar(ctx, x, top, rows, color, intensity);
+			}
+		});
+	}
+
+	function onMove(e: PointerEvent) {
+		const rect = canvas.getBoundingClientRect();
+		const x = e.clientX - rect.left;
+		pointerX = x;
+		const n = Math.max(1, data.length);
+		hover = Math.min(n - 1, Math.max(0, Math.floor((x / rect.width) * n)));
+	}
+
+	const active = $derived(hover != null ? data[hover] : null);
+	// Keep the tooltip inside the wrapper.
+	const tipLeft = $derived(Math.max(8, Math.min(width - 8, pointerX)));
+
+	$effect(() => {
+		// render() reads data, max, width, hover, height and color — all tracked as effect deps, so
+		// this re-runs whenever any of them change.
+		render();
+	});
+
+	$effect(() => {
+		if (!wrapper) return;
+		const ro = new ResizeObserver((entries) => {
+			width = entries[0].contentRect.width;
+		});
+		ro.observe(wrapper);
+		return () => ro.disconnect();
+	});
+</script>
+
+<div class="chart" bind:this={wrapper} style="height: {height}px">
+	<canvas
+		bind:this={canvas}
+		style="width: 100%; height: {height}px"
+		onpointermove={onMove}
+		onpointerleave={() => (hover = null)}
+	></canvas>
+
+	{#if active}
+		<div class="tip" style="left: {tipLeft}px" class:flip={tipLeft > width / 2}>
+			<div class="tip-head">
+				<span class="tip-date">{formatDay(active.date)}</span>
+				<span class="tip-total">{formatTokens(active.tokens)}</span>
+			</div>
+			<ul class="tip-models">
+				{#each active.models.slice(0, 4) as m (m.model)}
+					<li>
+						<span class="tip-model">{prettyModel(m.model)}</span>
+						<span class="tip-tokens">{formatTokens(m.tokens)}</span>
+					</li>
+				{/each}
+			</ul>
+		</div>
+	{/if}
+</div>
+
+<style>
+	.chart {
+		position: relative;
+		width: 100%;
+	}
+
+	canvas {
+		display: block;
+		image-rendering: pixelated;
+		cursor: crosshair;
+	}
+
+	.tip {
+		position: absolute;
+		top: calc(100% + 8px);
+		transform: translateX(-8px);
+		min-width: 190px;
+		padding: 0.65rem 0.75rem;
+		background: var(--surface);
+		border: 1px solid var(--surface-border);
+		border-radius: 10px;
+		box-shadow: var(--surface-shadow);
+		pointer-events: none;
+		z-index: 2;
+	}
+
+	.tip.flip {
+		transform: translateX(calc(-100% + 8px));
+	}
+
+	.tip-head {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: 1.5rem;
+		margin-bottom: 0.4rem;
+	}
+
+	.tip-date {
+		color: var(--text-muted);
+		font-size: 0.75rem;
+	}
+
+	.tip-total {
+		color: var(--text-primary);
+		font-weight: 600;
+		font-size: 0.9375rem;
+	}
+
+	.tip-models {
+		list-style: none;
+		margin: 0;
+		padding: 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.25rem;
+	}
+
+	.tip-models li {
+		display: flex;
+		justify-content: space-between;
+		gap: 1.5rem;
+		font-size: 0.8125rem;
+	}
+
+	.tip-model {
+		color: var(--text-secondary);
+	}
+
+	.tip-tokens {
+		color: var(--text-muted);
+		font-variant-numeric: tabular-nums;
+	}
+</style>

--- a/web/src/lib/components/UsageChart.svelte
+++ b/web/src/lib/components/UsageChart.svelte
@@ -1,54 +1,101 @@
 <script lang="ts">
 	import type { DailyUsage } from '$lib/usage';
 	import { CELL, DITHER_PURPLE, paintBar, type Rgb } from '$lib/dither/paint';
-	import { formatDay, formatTokens, prettyModel } from '$lib/format';
+	import { formatDay, formatDayShort, formatTokens, prettyModel } from '$lib/format';
+	import { ChevronLeft, ChevronRight } from 'lucide-svelte';
 
 	let {
 		daily,
 		color = DITHER_PURPLE,
 		height = 150,
-		maxDays = 90
-	}: { daily: DailyUsage[]; color?: Rgb; height?: number; maxDays?: number } = $props();
+		windowDays = 14
+	}: { daily: DailyUsage[]; color?: Rgb; height?: number; windowDays?: number } = $props();
 
-	// Newest `maxDays` days that had usage, oldest → newest so the chart reads left-to-right.
-	const data = $derived(daily.slice(-maxDays));
+	let offset = $state(0);
+
+	const total = $derived(daily.length);
+	const maxOffset = $derived(Math.max(0, total - windowDays));
+	const clampedOffset = $derived(Math.min(offset, maxOffset));
+	const end = $derived(total - clampedOffset);
+	const start = $derived(Math.max(0, end - windowDays));
+
+	const data = $derived(daily.slice(start, end));
 	const max = $derived(Math.max(1, ...data.map((d) => d.tokens)));
 
+	const canOlder = $derived(start > 0);
+	const canNewer = $derived(clampedOffset > 0);
+	const rangeLabel = $derived(
+		data.length
+			? `${formatDayShort(data[0].date)} – ${formatDayShort(data[data.length - 1].date)}`
+			: ''
+	);
+
+	function older() {
+		offset = Math.min(maxOffset, clampedOffset + windowDays);
+		hover = null;
+	}
+
+	function newer() {
+		offset = Math.max(0, clampedOffset - windowDays);
+		hover = null;
+	}
+
 	let canvas: HTMLCanvasElement;
+	let bloomCanvas: HTMLCanvasElement;
 	let wrapper: HTMLDivElement;
 	let width = $state(0);
 	let hover = $state<number | null>(null);
 	let pointerX = $state(0);
 
-	// Backing-canvas bar slots, so hover maths and drawing agree on where each bar sits.
 	function layout(cols: number) {
 		const n = Math.max(1, data.length);
 		const slot = cols / n;
 		const barW = Math.max(1, Math.round(slot * 0.68));
-		return { n, slot, barW };
+		return { slot, barW };
 	}
 
-	function render() {
-		if (!canvas || !width) return;
-		const cols = Math.max(8, Math.round(width / CELL));
-		const rows = Math.max(8, Math.round(height / CELL));
-		canvas.width = cols;
-		canvas.height = rows;
-		const ctx = canvas.getContext('2d');
-		if (!ctx) return;
-		ctx.clearRect(0, 0, cols, rows);
+	let ctx: CanvasRenderingContext2D | null = null;
+	let curCols = 0;
+	let curRows = 0;
+	let lastBar: number | null = null;
 
-		const { slot, barW } = layout(cols);
-		data.forEach((d, i) => {
-			const x0 = Math.round(i * slot + (slot - barW) / 2);
-			// sqrt keeps quiet days visible next to a spike without lying about the ordering.
-			const h = Math.round(Math.sqrt(d.tokens / max) * (rows - 2));
-			const top = rows - h;
-			const intensity = i === hover ? 1 : 0;
-			for (let x = x0; x < x0 + barW && x < cols; x++) {
-				paintBar(ctx, x, top, rows, color, intensity);
-			}
-		});
+	function paintOneBar(i: number, intensity: number) {
+		if (!ctx) return;
+		const { slot, barW } = layout(curCols);
+		const x0 = Math.round(i * slot + (slot - barW) / 2);
+		// sqrt keeps quiet days visible next to a spike without lying about the ordering.
+		const h = Math.round(Math.sqrt(data[i].tokens / max) * (curRows - 2));
+		const top = curRows - h;
+		// Clear first because paintBar uses partial alpha.
+		ctx.clearRect(x0, 0, barW, curRows);
+		for (let x = x0; x < x0 + barW && x < curCols; x++) {
+			paintBar(ctx, x, top, curRows, color, intensity);
+		}
+	}
+
+	// CSS blurs and additively blends this copy behind the crisp bars.
+	function syncBloom() {
+		if (!bloomCanvas) return;
+		bloomCanvas.width = curCols;
+		bloomCanvas.height = curRows;
+		const bctx = bloomCanvas.getContext('2d');
+		if (!bctx) return;
+		bctx.clearRect(0, 0, curCols, curRows);
+		bctx.drawImage(canvas, 0, 0);
+	}
+
+	function renderBase() {
+		if (!canvas || !width) return;
+		curCols = Math.max(8, Math.round(width / CELL));
+		curRows = Math.max(8, Math.round(height / CELL));
+		canvas.width = curCols;
+		canvas.height = curRows;
+		ctx = canvas.getContext('2d');
+		if (!ctx) return;
+		ctx.clearRect(0, 0, curCols, curRows);
+		data.forEach((_, i) => paintOneBar(i, 0));
+		syncBloom();
+		lastBar = null;
 	}
 
 	function onMove(e: PointerEvent) {
@@ -60,13 +107,22 @@
 	}
 
 	const active = $derived(hover != null ? data[hover] : null);
-	// Keep the tooltip inside the wrapper.
 	const tipLeft = $derived(Math.max(8, Math.min(width - 8, pointerX)));
 
 	$effect(() => {
-		// render() reads data, max, width, hover, height and color — all tracked as effect deps, so
-		// this re-runs whenever any of them change.
-		render();
+		renderBase();
+	});
+
+	$effect(() => {
+		const h = hover;
+		if (!ctx) return;
+		if (lastBar != null && lastBar < data.length) paintOneBar(lastBar, 0);
+		lastBar = null;
+		if (h != null && h < data.length) {
+			paintOneBar(h, 1);
+			lastBar = h;
+		}
+		syncBloom();
 	});
 
 	$effect(() => {
@@ -79,12 +135,36 @@
 	});
 </script>
 
+{#if rangeLabel}
+	<div class="head">
+		<span class="range">{rangeLabel}</span>
+		{#if canOlder || canNewer}
+			<div class="nav">
+				<button type="button" onclick={older} disabled={!canOlder} aria-label="Show earlier days">
+					<ChevronLeft size={14} />
+				</button>
+				<button type="button" onclick={newer} disabled={!canNewer} aria-label="Show later days">
+					<ChevronRight size={14} />
+				</button>
+			</div>
+		{/if}
+	</div>
+{/if}
+
 <div class="chart" bind:this={wrapper} style="height: {height}px">
 	<canvas
 		bind:this={canvas}
+		class="crisp"
 		style="width: 100%; height: {height}px"
 		onpointermove={onMove}
 		onpointerleave={() => (hover = null)}
+	></canvas>
+
+	<canvas
+		bind:this={bloomCanvas}
+		class="bloom"
+		style="width: 100%; height: {height}px"
+		aria-hidden="true"
 	></canvas>
 
 	{#if active}
@@ -106,6 +186,43 @@
 </div>
 
 <style>
+	.head {
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		margin-bottom: 0.6rem;
+		font-size: 0.75rem;
+		color: var(--text-muted);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.nav {
+		display: flex;
+		gap: 2px;
+	}
+
+	.nav button {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		padding: 2px;
+		background: none;
+		border: none;
+		color: var(--text-muted);
+		cursor: pointer;
+	}
+
+	.nav button:disabled {
+		opacity: 0.3;
+		cursor: default;
+	}
+
+	@media (hover: hover) and (pointer: fine) {
+		.nav button:not(:disabled):hover {
+			color: var(--text-secondary);
+		}
+	}
+
 	.chart {
 		position: relative;
 		width: 100%;
@@ -115,6 +232,17 @@
 		display: block;
 		image-rendering: pixelated;
 		cursor: crosshair;
+	}
+
+	.bloom {
+		position: absolute;
+		inset: 0;
+		pointer-events: none;
+		image-rendering: auto;
+		filter: blur(4px) brightness(1.3) saturate(1.5);
+		mix-blend-mode: plus-lighter;
+		opacity: 0.6;
+		z-index: 1;
 	}
 
 	.tip {

--- a/web/src/lib/components/UsageSection.svelte
+++ b/web/src/lib/components/UsageSection.svelte
@@ -1,0 +1,113 @@
+<script lang="ts">
+	import type { UsageStats } from '$lib/usage';
+	import { formatTokens, prettyModel } from '$lib/format';
+	import UsageChart from './UsageChart.svelte';
+	import { ChevronDown } from 'lucide-svelte';
+	import { slide } from 'svelte/transition';
+
+	let { stats }: { stats: UsageStats } = $props();
+	let open = $state(false);
+
+	const rows = $derived([
+		{ label: 'tokens', value: formatTokens(stats.totals.tokens) },
+		{ label: 'contributions', value: stats.totals.contributions.toLocaleString('en-US') },
+		{ label: 'active days', value: String(stats.totals.activeDays) },
+		{ label: 'longest streak', value: `${stats.totals.longestStreak}d` },
+		{ label: 'top model', value: prettyModel(stats.totals.topModel) }
+	]);
+</script>
+
+<section class="usage">
+	<button class="toggle" onclick={() => (open = !open)} aria-expanded={open} type="button">
+		<span>ai usage</span>
+		<ChevronDown size={14} class="chev {open ? 'open' : ''}" />
+	</button>
+
+	{#if open}
+		<div class="panel" transition:slide={{ duration: 200 }}>
+			<dl class="stats">
+				{#each rows as row (row.label)}
+					<div class="row">
+						<dt>{row.label}</dt>
+						<dd>{row.value}</dd>
+					</div>
+				{/each}
+			</dl>
+
+			{#if stats.daily.length}
+				<div class="chart-wrap">
+					<UsageChart daily={stats.daily} height={110} />
+				</div>
+			{/if}
+		</div>
+	{/if}
+</section>
+
+<style>
+	.usage {
+		margin-top: 2.5rem;
+	}
+
+	.toggle {
+		display: inline-flex;
+		align-items: center;
+		gap: 5px;
+		background: none;
+		border: none;
+		padding: 0;
+		cursor: pointer;
+		color: var(--text-muted);
+		font-family: inherit;
+		font-size: 0.8125rem;
+	}
+
+	.toggle :global(.chev) {
+		transition: transform 0.2s ease;
+	}
+
+	.toggle :global(.chev.open) {
+		transform: rotate(180deg);
+	}
+
+	@media (hover: hover) and (pointer: fine) {
+		.toggle:hover {
+			color: var(--text-secondary);
+		}
+	}
+
+	.stats {
+		margin: 1.25rem 0 0 0;
+		display: flex;
+		flex-direction: column;
+		gap: 0.5rem;
+		max-width: 260px;
+	}
+
+	.row {
+		display: flex;
+		justify-content: space-between;
+		align-items: baseline;
+		gap: 1.5rem;
+		font-size: 0.8125rem;
+	}
+
+	dt {
+		color: var(--text-muted);
+	}
+
+	dd {
+		margin: 0;
+		color: var(--text-primary);
+		font-variant-numeric: tabular-nums;
+	}
+
+	.chart-wrap {
+		margin-top: 1.5rem;
+	}
+
+	@media (prefers-reduced-motion: reduce) {
+		.toggle :global(.chev) {
+			transition: none;
+		}
+	}
+</style>

--- a/web/src/lib/components/UsageSection.svelte
+++ b/web/src/lib/components/UsageSection.svelte
@@ -1,12 +1,10 @@
 <script lang="ts">
 	import type { UsageStats } from '$lib/usage';
 	import { formatTokens, prettyModel } from '$lib/format';
+	import CollapsibleStatsSection from './CollapsibleStatsSection.svelte';
 	import UsageChart from './UsageChart.svelte';
-	import { ChevronDown } from 'lucide-svelte';
-	import { slide } from 'svelte/transition';
 
 	let { stats }: { stats: UsageStats } = $props();
-	let open = $state(false);
 
 	const rows = $derived([
 		{ label: 'tokens', value: formatTokens(stats.totals.tokens) },
@@ -17,97 +15,16 @@
 	]);
 </script>
 
-<section class="usage">
-	<button class="toggle" onclick={() => (open = !open)} aria-expanded={open} type="button">
-		<span>ai usage</span>
-		<ChevronDown size={14} class="chev {open ? 'open' : ''}" />
-	</button>
-
-	{#if open}
-		<div class="panel" transition:slide={{ duration: 200 }}>
-			<dl class="stats">
-				{#each rows as row (row.label)}
-					<div class="row">
-						<dt>{row.label}</dt>
-						<dd>{row.value}</dd>
-					</div>
-				{/each}
-			</dl>
-
-			{#if stats.daily.length}
-				<div class="chart-wrap">
-					<UsageChart daily={stats.daily} height={110} />
-				</div>
-			{/if}
+<CollapsibleStatsSection title="ai usage" {rows} marginTop="2.5rem">
+	{#if stats.daily.length}
+		<div class="chart-wrap">
+			<UsageChart daily={stats.daily} height={110} />
 		</div>
 	{/if}
-</section>
+</CollapsibleStatsSection>
 
 <style>
-	.usage {
-		margin-top: 2.5rem;
-	}
-
-	.toggle {
-		display: inline-flex;
-		align-items: center;
-		gap: 5px;
-		background: none;
-		border: none;
-		padding: 0;
-		cursor: pointer;
-		color: var(--text-muted);
-		font-family: inherit;
-		font-size: 0.8125rem;
-	}
-
-	.toggle :global(.chev) {
-		transition: transform 0.2s ease;
-	}
-
-	.toggle :global(.chev.open) {
-		transform: rotate(180deg);
-	}
-
-	@media (hover: hover) and (pointer: fine) {
-		.toggle:hover {
-			color: var(--text-secondary);
-		}
-	}
-
-	.stats {
-		margin: 1.25rem 0 0 0;
-		display: flex;
-		flex-direction: column;
-		gap: 0.5rem;
-		max-width: 260px;
-	}
-
-	.row {
-		display: flex;
-		justify-content: space-between;
-		align-items: baseline;
-		gap: 1.5rem;
-		font-size: 0.8125rem;
-	}
-
-	dt {
-		color: var(--text-muted);
-	}
-
-	dd {
-		margin: 0;
-		color: var(--text-primary);
-		font-variant-numeric: tabular-nums;
-	}
-
 	.chart-wrap {
 		margin-top: 1.5rem;
-	}
-
-	@media (prefers-reduced-motion: reduce) {
-		.toggle :global(.chev) {
-			transition: none;
-		}
 	}
 </style>

--- a/web/src/lib/dither/paint.ts
+++ b/web/src/lib/dither/paint.ts
@@ -1,0 +1,100 @@
+// Ordered-dither painting, ported from dither-kit (github.com/Boring-Software-Inc/dither-kit,
+// registry/dither-kit/dither-paint.ts) to plain framework-free canvas so it runs in Svelte.
+//
+// Guiding rule kept from the original: work in opacities of one colour, not different shades — a
+// single fill whose alpha follows the dither density reads correctly on both light and dark themes.
+
+export type Rgb = [number, number, number];
+
+// 4×4 Bayer matrix, normalized to 0–1 thresholds — the exact matrix dither-kit dithers with.
+export const BAYER = [
+	[0, 8, 2, 10],
+	[12, 4, 14, 6],
+	[3, 11, 1, 9],
+	[15, 7, 13, 5]
+].map((row) => row.map((v) => (v + 0.5) / 16));
+
+/** css px per dither cell — chunky enough to read pixelated. */
+export const CELL = 3;
+/** Opacity of the top edge outline (just under solid, so it reads as a soft edge). */
+const BORDER_ALPHA = 0.72;
+/** Opacity of a dither "off" cell relative to an "on" cell. */
+const OFF_TIER = 0.4;
+
+const clamp01 = (t: number) => (t < 0 ? 0 : t > 1 ? 1 : t);
+const rgba = ([r, g, b]: Rgb, a: number) => `rgba(${r},${g},${b},${a})`;
+
+/**
+ * Fill backing-canvas column `x` from `top` down to `floor` with the ordered-dither scatter — solid
+ * at the floor, dissolving upward toward the value line — then cap the top with a soft edge outline.
+ * `intensity` (0–1) lifts opacity on hover. The single source of the bar's dither texture.
+ */
+export function paintBar(
+	ctx: CanvasRenderingContext2D,
+	x: number,
+	top: number,
+	floor: number,
+	fill: Rgb,
+	intensity = 0
+) {
+	const t = Math.round(top);
+	const f = Math.round(floor);
+	const depth = f - t;
+	if (depth <= 0) {
+		ctx.fillStyle = rgba(fill, BORDER_ALPHA);
+		ctx.fillRect(x, t, 1, 1);
+		return;
+	}
+	for (let y = t; y < f; y++) {
+		// Inverted falloff: dense at the floor, thinning as it rises toward the outline.
+		const density = (y - t) / depth;
+		const lit = density > BAYER[y & 3][x & 3] - 0.1 * intensity;
+		const k = (0.3 + density * 0.7) * (1 + 0.22 * intensity);
+		const alpha = clamp01(lit ? k : k * OFF_TIER);
+		ctx.fillStyle = rgba(fill, alpha);
+		ctx.fillRect(x, y, 1, 1);
+	}
+	// Top edge outline (the fill fades out here) with a faint feather row beneath.
+	ctx.fillStyle = rgba(fill, BORDER_ALPHA);
+	ctx.fillRect(x, t, 1, 1);
+	if (depth > 1) {
+		ctx.fillStyle = rgba(fill, BORDER_ALPHA * 0.5);
+		ctx.fillRect(x, t + 1, 1, 1);
+	}
+}
+
+/** Opacity of an unlit cell in a grid — a faint slot so empty days still read as a grid. */
+const SLOT_ALPHA = 0.08;
+
+/**
+ * Fill a `size`×`size` grid cell at (`x0`,`y0`) with an ordered-dither block whose density follows
+ * `level` (0–1): level 0 is a barely-there slot, level 1 a solid square, and the tiers between scatter
+ * in the classic Bayer pattern. The Bayer lookup uses absolute backing coords, so the dither field
+ * stays coherent across the whole grid instead of restarting per cell. `intensity` (0–1) lifts the
+ * whole cell on hover. The single source of the contribution grid's dither texture.
+ */
+export function paintCell(
+	ctx: CanvasRenderingContext2D,
+	x0: number,
+	y0: number,
+	size: number,
+	fill: Rgb,
+	level: number,
+	intensity = 0
+) {
+	const l = clamp01(level);
+	for (let y = y0; y < y0 + size; y++) {
+		for (let x = x0; x < x0 + size; x++) {
+			const lit = l > BAYER[y & 3][x & 3];
+			const alpha = lit
+				? clamp01((0.5 + 0.5 * l) * (1 + 0.25 * intensity))
+				: clamp01(SLOT_ALPHA * (1 + intensity * 3));
+			ctx.fillStyle = rgba(fill, alpha);
+			ctx.fillRect(x, y, 1, 1);
+		}
+	}
+}
+
+// Series colours, matching dither-kit's palette seeds.
+export const DITHER_PURPLE: Rgb = [150, 110, 255];
+export const DITHER_GREEN: Rgb = [40, 210, 110];

--- a/web/src/lib/dither/paint.ts
+++ b/web/src/lib/dither/paint.ts
@@ -1,12 +1,8 @@
-// Ordered-dither painting, ported from dither-kit (github.com/Boring-Software-Inc/dither-kit,
-// registry/dither-kit/dither-paint.ts) to plain framework-free canvas so it runs in Svelte.
-//
-// Guiding rule kept from the original: work in opacities of one colour, not different shades — a
-// single fill whose alpha follows the dither density reads correctly on both light and dark themes.
+// Ported from dither-kit's dither-paint.ts to plain canvas.
 
 export type Rgb = [number, number, number];
 
-// 4×4 Bayer matrix, normalized to 0–1 thresholds — the exact matrix dither-kit dithers with.
+// 4×4 Bayer matrix normalized to 0–1 thresholds.
 export const BAYER = [
 	[0, 8, 2, 10],
 	[12, 4, 14, 6],
@@ -14,21 +10,13 @@ export const BAYER = [
 	[15, 7, 13, 5]
 ].map((row) => row.map((v) => (v + 0.5) / 16));
 
-/** css px per dither cell — chunky enough to read pixelated. */
-export const CELL = 3;
-/** Opacity of the top edge outline (just under solid, so it reads as a soft edge). */
+export const CELL = 2;
 const BORDER_ALPHA = 0.72;
-/** Opacity of a dither "off" cell relative to an "on" cell. */
 const OFF_TIER = 0.4;
 
 const clamp01 = (t: number) => (t < 0 ? 0 : t > 1 ? 1 : t);
 const rgba = ([r, g, b]: Rgb, a: number) => `rgba(${r},${g},${b},${a})`;
 
-/**
- * Fill backing-canvas column `x` from `top` down to `floor` with the ordered-dither scatter — solid
- * at the floor, dissolving upward toward the value line — then cap the top with a soft edge outline.
- * `intensity` (0–1) lifts opacity on hover. The single source of the bar's dither texture.
- */
 export function paintBar(
 	ctx: CanvasRenderingContext2D,
 	x: number,
@@ -54,7 +42,7 @@ export function paintBar(
 		ctx.fillStyle = rgba(fill, alpha);
 		ctx.fillRect(x, y, 1, 1);
 	}
-	// Top edge outline (the fill fades out here) with a faint feather row beneath.
+	// Cap the fading fill with a faint feather row.
 	ctx.fillStyle = rgba(fill, BORDER_ALPHA);
 	ctx.fillRect(x, t, 1, 1);
 	if (depth > 1) {
@@ -63,16 +51,8 @@ export function paintBar(
 	}
 }
 
-/** Opacity of an unlit cell in a grid — a faint slot so empty days still read as a grid. */
 const SLOT_ALPHA = 0.08;
 
-/**
- * Fill a `size`×`size` grid cell at (`x0`,`y0`) with an ordered-dither block whose density follows
- * `level` (0–1): level 0 is a barely-there slot, level 1 a solid square, and the tiers between scatter
- * in the classic Bayer pattern. The Bayer lookup uses absolute backing coords, so the dither field
- * stays coherent across the whole grid instead of restarting per cell. `intensity` (0–1) lifts the
- * whole cell on hover. The single source of the contribution grid's dither texture.
- */
 export function paintCell(
 	ctx: CanvasRenderingContext2D,
 	x0: number,
@@ -95,6 +75,5 @@ export function paintCell(
 	}
 }
 
-// Series colours, matching dither-kit's palette seeds.
 export const DITHER_PURPLE: Rgb = [150, 110, 255];
 export const DITHER_GREEN: Rgb = [40, 210, 110];

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,0 +1,54 @@
+/** 23_500_000_000 → "23.5B", 362_000_000 → "362M", 455_000 → "455k". */
+export function formatTokens(n: number): string {
+	if (n >= 999.5e9) return `${trim(n / 1e12)}T`;
+	if (n >= 999.5e6) return `${trim(n / 1e9)}B`;
+	if (n >= 999.5e3) return `${trim(n / 1e6)}M`;
+	if (n >= 1e3) return `${trim(n / 1e3)}k`;
+	return String(Math.round(n));
+}
+
+function trim(n: number): string {
+	// One decimal, but drop a trailing ".0" so "23.0B" reads as "23B".
+	return n.toFixed(n < 100 ? 1 : 0).replace(/\.0$/, '');
+}
+
+export function formatUsd(n: number): string {
+	return n.toLocaleString('en-US', {
+		style: 'currency',
+		currency: 'USD',
+		maximumFractionDigits: 2
+	});
+}
+
+/** "anthropic/claude-opus-4-8" → "opus 4.8", "anthropic/claude-haiku-4-5" → "haiku 4.5". */
+export function prettyModel(model: string | null | undefined): string {
+	if (!model) return 'unknown';
+	const bare = model.includes('/') ? model.slice(model.lastIndexOf('/') + 1) : model;
+	const name = bare.replace(/^claude-/, '');
+	// Split the trailing version segments (opus-4-8 → family "opus", version "4.8").
+	const parts = name.split('-');
+	const versionStart = parts.findIndex((p) => /^\d+$/.test(p));
+	if (versionStart === -1) return name.replace(/-/g, ' ');
+	const family = parts.slice(0, versionStart).join(' ');
+	// Take the short numeric segments as the version (e.g. 4, 8) and stop at anything else — a long
+	// date suffix like "20251001" or a word suffix like "codex" isn't part of the version.
+	const version: string[] = [];
+	for (const p of parts.slice(versionStart)) {
+		if (/^\d+$/.test(p) && p.length <= 3) version.push(p);
+		else break;
+	}
+	return `${family} ${version.join('.')}`.trim();
+}
+
+/** UTC "2026-06-17" → "jun 17, 2026". */
+export function formatDay(date: string): string {
+	const d = new Date(`${date}T00:00:00Z`);
+	return d
+		.toLocaleDateString('en-US', {
+			month: 'short',
+			day: 'numeric',
+			year: 'numeric',
+			timeZone: 'UTC'
+		})
+		.toLowerCase();
+}

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,4 +1,3 @@
-/** 23_500_000_000 → "23.5B", 362_000_000 → "362M", 455_000 → "455k". */
 export function formatTokens(n: number): string {
 	if (n >= 999.5e9) return `${trim(n / 1e12)}T`;
 	if (n >= 999.5e6) return `${trim(n / 1e9)}B`;
@@ -8,16 +7,7 @@ export function formatTokens(n: number): string {
 }
 
 function trim(n: number): string {
-	// One decimal, but drop a trailing ".0" so "23.0B" reads as "23B".
 	return n.toFixed(n < 100 ? 1 : 0).replace(/\.0$/, '');
-}
-
-export function formatUsd(n: number): string {
-	return n.toLocaleString('en-US', {
-		style: 'currency',
-		currency: 'USD',
-		maximumFractionDigits: 2
-	});
 }
 
 /** "anthropic/claude-opus-4-8" → "opus 4.8", "anthropic/claude-haiku-4-5" → "haiku 4.5". */
@@ -25,13 +15,11 @@ export function prettyModel(model: string | null | undefined): string {
 	if (!model) return 'unknown';
 	const bare = model.includes('/') ? model.slice(model.lastIndexOf('/') + 1) : model;
 	const name = bare.replace(/^claude-/, '');
-	// Split the trailing version segments (opus-4-8 → family "opus", version "4.8").
 	const parts = name.split('-');
 	const versionStart = parts.findIndex((p) => /^\d+$/.test(p));
 	if (versionStart === -1) return name.replace(/-/g, ' ');
 	const family = parts.slice(0, versionStart).join(' ');
-	// Take the short numeric segments as the version (e.g. 4, 8) and stop at anything else — a long
-	// date suffix like "20251001" or a word suffix like "codex" isn't part of the version.
+	// Ignore long date suffixes and non-numeric provider suffixes.
 	const version: string[] = [];
 	for (const p of parts.slice(versionStart)) {
 		if (/^\d+$/.test(p) && p.length <= 3) version.push(p);
@@ -40,7 +28,6 @@ export function prettyModel(model: string | null | undefined): string {
 	return `${family} ${version.join('.')}`.trim();
 }
 
-/** UTC "2026-06-17" → "jun 17, 2026". */
 export function formatDay(date: string): string {
 	const d = new Date(`${date}T00:00:00Z`);
 	return d
@@ -48,6 +35,17 @@ export function formatDay(date: string): string {
 			month: 'short',
 			day: 'numeric',
 			year: 'numeric',
+			timeZone: 'UTC'
+		})
+		.toLowerCase();
+}
+
+export function formatDayShort(date: string): string {
+	const d = new Date(`${date}T00:00:00Z`);
+	return d
+		.toLocaleDateString('en-US', {
+			month: 'short',
+			day: 'numeric',
 			timeZone: 'UTC'
 		})
 		.toLowerCase();

--- a/web/src/lib/github.ts
+++ b/web/src/lib/github.ts
@@ -1,0 +1,23 @@
+// Shared GitHub-contribution shapes. Kept out of $lib/server so client components can import the
+// types (mirrors $lib/usage for the AI-usage section).
+
+export type ContributionDay = {
+	/** UTC day, YYYY-MM-DD. */
+	date: string;
+	count: number;
+	/** GitHub's own quartile bucket (NONE → FOURTH_QUARTILE), mapped to 0–4. Drives the dither density. */
+	level: 0 | 1 | 2 | 3 | 4;
+};
+
+export type ContributionStats = {
+	updatedAt: number;
+	/** Total contributions in the trailing-year window GitHub reports. */
+	total: number;
+	activeDays: number;
+	longestStreak: number;
+	/** Trailing run of active days; an empty "today" is treated as in-progress, not a break. */
+	currentStreak: number;
+	busiestDay: { date: string; count: number } | null;
+	/** Calendar columns, oldest → newest; each is up to 7 days, one per weekday present. */
+	weeks: ContributionDay[][];
+};

--- a/web/src/lib/github.ts
+++ b/web/src/lib/github.ts
@@ -1,23 +1,15 @@
-// Shared GitHub-contribution shapes. Kept out of $lib/server so client components can import the
-// types (mirrors $lib/usage for the AI-usage section).
-
 export type ContributionDay = {
-	/** UTC day, YYYY-MM-DD. */
 	date: string;
 	count: number;
-	/** GitHub's own quartile bucket (NONE → FOURTH_QUARTILE), mapped to 0–4. Drives the dither density. */
 	level: 0 | 1 | 2 | 3 | 4;
 };
 
 export type ContributionStats = {
 	updatedAt: number;
-	/** Total contributions in the trailing-year window GitHub reports. */
 	total: number;
 	activeDays: number;
 	longestStreak: number;
-	/** Trailing run of active days; an empty "today" is treated as in-progress, not a break. */
 	currentStreak: number;
 	busiestDay: { date: string; count: number } | null;
-	/** Calendar columns, oldest → newest; each is up to 7 days, one per weekday present. */
 	weeks: ContributionDay[][];
 };

--- a/web/src/lib/server/autumn.ts
+++ b/web/src/lib/server/autumn.ts
@@ -1,16 +1,8 @@
 import { env } from '$env/dynamic/private';
 
-// Autumn (useautumn.com) is the backend Summer stores AI-coding usage in. Each token event lands on
-// the `usage_in_usd` feature: `value` is the USD Autumn priced it at (via Models.dev) and the token
-// counts + model live in `properties`. This module is the *raw Autumn access layer* only — fetching
-// events and folding them into daily (date, model) rollups. Persistence + the homepage-facing
-// `getUsageStats()` live in `$lib/server/usage`. Server-only — the secret key must never reach the
-// client.
-
 const API_URL = 'https://api.useautumn.com';
 const USAGE_FEATURE = 'usage_in_usd';
 const PAGE = 1000;
-/** Safety cap on incremental sweeps so a runaway loop can't page forever. Backfill passes Infinity. */
 const DEFAULT_CAP = 20_000;
 
 export type RawEvent = {
@@ -20,13 +12,17 @@ export type RawEvent = {
 	properties?: Record<string, unknown>;
 };
 
-/** One folded (UTC-day, model) bucket. */
 export type DailyRollup = {
 	date: string;
 	model: string;
 	tokens: number;
 	spendUsd: number;
 	events: number;
+};
+
+type CursorPage<T> = {
+	list: T[];
+	next_cursor?: string | null;
 };
 
 async function autumn<T>(path: string, body: unknown): Promise<T> {
@@ -48,13 +44,24 @@ async function autumn<T>(path: string, body: unknown): Promise<T> {
 	return res.json() as Promise<T>;
 }
 
-/** The Summer-managed customer (the developer whose usage we track). */
 export async function resolveCustomerId(): Promise<string | null> {
-	const res = await autumn<{
-		list: Array<{ id: string; metadata?: Record<string, unknown> | null }>;
-	}>('/v1/customers.list', { limit: 200, offset: 0 });
-	const summer = res.list.find((c) => c.metadata?.summer === true);
-	return summer?.id ?? res.list[0]?.id ?? null;
+	type Customer = { id: string; metadata?: Record<string, unknown> | null };
+	let cursor: string | undefined;
+	let foundAny = false;
+
+	do {
+		const res = await autumn<CursorPage<Customer>>('/v1/customers.list', {
+			limit: 200,
+			...(cursor ? { start_cursor: cursor } : {})
+		});
+		foundAny ||= res.list.length > 0;
+		const summer = res.list.find((customer) => customer.metadata?.summer === true);
+		if (summer) return summer.id;
+		cursor = res.next_cursor ?? undefined;
+	} while (cursor);
+
+	if (foundAny) throw new Error('No Autumn customer with metadata.summer=true found');
+	return null;
 }
 
 const num = (v: unknown) => {
@@ -66,7 +73,8 @@ const dayKey = (ms: number) => new Date(ms).toISOString().slice(0, 10);
 /**
  * Page through usage events (newest first). Stops once an event is older than `sinceMs` (the API
  * returns newest-first, so once we cross the boundary everything after is older too) or once `cap`
- * events have been fetched. Pass `sinceMs = 0` + `cap = Infinity` for a full backfill.
+ * events have been fetched. Pagination follows Autumn's opaque `next_cursor`; reaching the safety
+ * cap before the requested window is complete throws instead of replacing rollups with partial data.
  */
 export async function fetchEventsSince(
 	customerId: string,
@@ -74,14 +82,17 @@ export async function fetchEventsSince(
 	cap: number = DEFAULT_CAP
 ): Promise<RawEvent[]> {
 	const out: RawEvent[] = [];
-	for (let offset = 0; offset < cap; offset += PAGE) {
-		const res = await autumn<{ list: RawEvent[]; has_more?: boolean }>('/v1/events.list', {
+	let cursor: string | undefined;
+
+	do {
+		const limit = Math.min(PAGE, cap - out.length);
+		const res = await autumn<CursorPage<RawEvent>>('/v1/events.list', {
 			customer_id: customerId,
 			feature_id: USAGE_FEATURE,
-			limit: PAGE,
-			offset
+			limit,
+			...(cursor ? { start_cursor: cursor } : {})
 		});
-		const list = res.list ?? [];
+		const list = res.list;
 		let crossedBoundary = false;
 		for (const event of list) {
 			if (event.timestamp < sinceMs) {
@@ -90,13 +101,17 @@ export async function fetchEventsSince(
 			}
 			out.push(event);
 		}
-		if (crossedBoundary || list.length < PAGE || !res.has_more) break;
-	}
+		if (crossedBoundary) break;
+
+		cursor = res.next_cursor ?? undefined;
+		if (cursor && out.length >= cap) {
+			throw new Error(`Autumn event sync exceeded the ${cap.toLocaleString('en-US')} event cap`);
+		}
+	} while (cursor);
+
 	return out;
 }
 
-/** Fold events into (date, model) rollups. Order-independent → re-running over the same events
- * yields identical rollups (the property the transactional replace relies on for idempotency). */
 export function eventsToDailyRollups(events: RawEvent[]): DailyRollup[] {
 	const byKey = new Map<string, DailyRollup>();
 	for (const event of events) {

--- a/web/src/lib/server/autumn.ts
+++ b/web/src/lib/server/autumn.ts
@@ -1,0 +1,122 @@
+import { env } from '$env/dynamic/private';
+
+// Autumn (useautumn.com) is the backend Summer stores AI-coding usage in. Each token event lands on
+// the `usage_in_usd` feature: `value` is the USD Autumn priced it at (via Models.dev) and the token
+// counts + model live in `properties`. This module is the *raw Autumn access layer* only — fetching
+// events and folding them into daily (date, model) rollups. Persistence + the homepage-facing
+// `getUsageStats()` live in `$lib/server/usage`. Server-only — the secret key must never reach the
+// client.
+
+const API_URL = 'https://api.useautumn.com';
+const USAGE_FEATURE = 'usage_in_usd';
+const PAGE = 1000;
+/** Safety cap on incremental sweeps so a runaway loop can't page forever. Backfill passes Infinity. */
+const DEFAULT_CAP = 20_000;
+
+export type RawEvent = {
+	id: string;
+	timestamp: number;
+	value?: number;
+	properties?: Record<string, unknown>;
+};
+
+/** One folded (UTC-day, model) bucket. */
+export type DailyRollup = {
+	date: string;
+	model: string;
+	tokens: number;
+	spendUsd: number;
+	events: number;
+};
+
+async function autumn<T>(path: string, body: unknown): Promise<T> {
+	const key = env.AUTUMN_SECRET_KEY;
+	if (!key) throw new Error('AUTUMN_SECRET_KEY is not set');
+	const res = await fetch(new URL(path, API_URL), {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${key}`,
+			'Content-Type': 'application/json',
+			'X-API-Version': '2.1.0'
+		},
+		body: JSON.stringify(body)
+	});
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`Autumn ${path} failed (${res.status}): ${text.slice(0, 200)}`);
+	}
+	return res.json() as Promise<T>;
+}
+
+/** The Summer-managed customer (the developer whose usage we track). */
+export async function resolveCustomerId(): Promise<string | null> {
+	const res = await autumn<{
+		list: Array<{ id: string; metadata?: Record<string, unknown> | null }>;
+	}>('/v1/customers.list', { limit: 200, offset: 0 });
+	const summer = res.list.find((c) => c.metadata?.summer === true);
+	return summer?.id ?? res.list[0]?.id ?? null;
+}
+
+const num = (v: unknown) => {
+	const n = Number(v);
+	return Number.isFinite(n) ? n : 0;
+};
+const dayKey = (ms: number) => new Date(ms).toISOString().slice(0, 10);
+
+/**
+ * Page through usage events (newest first). Stops once an event is older than `sinceMs` (the API
+ * returns newest-first, so once we cross the boundary everything after is older too) or once `cap`
+ * events have been fetched. Pass `sinceMs = 0` + `cap = Infinity` for a full backfill.
+ */
+export async function fetchEventsSince(
+	customerId: string,
+	sinceMs: number,
+	cap: number = DEFAULT_CAP
+): Promise<RawEvent[]> {
+	const out: RawEvent[] = [];
+	for (let offset = 0; offset < cap; offset += PAGE) {
+		const res = await autumn<{ list: RawEvent[]; has_more?: boolean }>('/v1/events.list', {
+			customer_id: customerId,
+			feature_id: USAGE_FEATURE,
+			limit: PAGE,
+			offset
+		});
+		const list = res.list ?? [];
+		let crossedBoundary = false;
+		for (const event of list) {
+			if (event.timestamp < sinceMs) {
+				crossedBoundary = true;
+				break;
+			}
+			out.push(event);
+		}
+		if (crossedBoundary || list.length < PAGE || !res.has_more) break;
+	}
+	return out;
+}
+
+/** Fold events into (date, model) rollups. Order-independent → re-running over the same events
+ * yields identical rollups (the property the transactional replace relies on for idempotency). */
+export function eventsToDailyRollups(events: RawEvent[]): DailyRollup[] {
+	const byKey = new Map<string, DailyRollup>();
+	for (const event of events) {
+		const p = event.properties ?? {};
+		const model = typeof p.model === 'string' ? p.model : 'unknown';
+		const tokens =
+			num(p.input_tokens) +
+			num(p.output_tokens) +
+			num(p.cache_read_tokens) +
+			num(p.cache_write_tokens);
+		const date = dayKey(event.timestamp);
+		const key = `${date}\0${model}`;
+		let bucket = byKey.get(key);
+		if (!bucket) {
+			bucket = { date, model, tokens: 0, spendUsd: 0, events: 0 };
+			byKey.set(key, bucket);
+		}
+		bucket.tokens += tokens;
+		bucket.spendUsd += num(event.value);
+		bucket.events += 1;
+	}
+	return [...byKey.values()];
+}

--- a/web/src/lib/server/db/index.ts
+++ b/web/src/lib/server/db/index.ts
@@ -1,0 +1,32 @@
+import { env } from '$env/dynamic/private';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import pg from 'pg';
+import * as schema from './schema';
+
+function createDatabase() {
+	// PlanetScale Postgres. DATABASE_URL is the pooled (PgBouncer / :6432) connection — right for the
+	// short read/write bursts the page and cron do. Validate it here so callers can handle missing
+	// configuration without failing while their route module is being imported.
+	const connectionString = env.DATABASE_URL;
+	if (!connectionString) throw new Error('DATABASE_URL is not set');
+
+	const pool = new pg.Pool({
+		connectionString,
+		ssl: { rejectUnauthorized: true }
+	});
+
+	// On Vercel Fluid Compute, drain in-flight queries before the instance is frozen/shut down. Loaded
+	// lazily so the pool still works outside Vercel (local dev, other hosts) where the module is absent.
+	import('@vercel/functions')
+		.then(({ attachDatabasePool }) => attachDatabasePool(pool))
+		.catch(() => {});
+
+	return drizzle(pool, { schema });
+}
+
+let database: ReturnType<typeof createDatabase> | null = null;
+
+export function getDb() {
+	database ??= createDatabase();
+	return database;
+}

--- a/web/src/lib/server/db/index.ts
+++ b/web/src/lib/server/db/index.ts
@@ -4,9 +4,6 @@ import pg from 'pg';
 import * as schema from './schema';
 
 function createDatabase() {
-	// PlanetScale Postgres. DATABASE_URL is the pooled (PgBouncer / :6432) connection — right for the
-	// short read/write bursts the page and cron do. Validate it here so callers can handle missing
-	// configuration without failing while their route module is being imported.
 	const connectionString = env.DATABASE_URL;
 	if (!connectionString) throw new Error('DATABASE_URL is not set');
 
@@ -15,8 +12,7 @@ function createDatabase() {
 		ssl: { rejectUnauthorized: true }
 	});
 
-	// On Vercel Fluid Compute, drain in-flight queries before the instance is frozen/shut down. Loaded
-	// lazily so the pool still works outside Vercel (local dev, other hosts) where the module is absent.
+	// Drain in-flight queries on Vercel while keeping the pool portable to other hosts.
 	import('@vercel/functions')
 		.then(({ attachDatabasePool }) => attachDatabasePool(pool))
 		.catch(() => {});

--- a/web/src/lib/server/db/schema.ts
+++ b/web/src/lib/server/db/schema.ts
@@ -9,33 +9,20 @@ import {
 	timestamp
 } from 'drizzle-orm/pg-core';
 
-/**
- * Pre-computed daily usage rollups — one row per (UTC day, model). The homepage stats are all
- * derivable from these rows, so a page view never has to touch Autumn. The daily Vercel cron
- * recomputes recent days and replaces them (see `syncUsage` in `$lib/server/usage`).
- */
 export const usageDaily = pgTable(
 	'usage_daily',
 	{
-		/** UTC day, "YYYY-MM-DD". */
 		date: date('date', { mode: 'string' }).notNull(),
-		/** Model id, e.g. "anthropic/claude-opus-4-8". */
 		model: text('model').notNull(),
-		/** input + output + cache_read + cache_write tokens summed over the day's events. */
 		tokens: bigint('tokens', { mode: 'number' }).notNull(),
-		/** Summed Autumn `value` (USD). */
 		spendUsd: doublePrecision('spend_usd').notNull(),
-		/** Number of contributing events. */
 		events: integer('events').notNull()
 	},
 	(t) => [primaryKey({ columns: [t.date, t.model] })]
 );
 
-/** Single-row sync cursor for the Autumn → DB rollup job. */
 export const syncState = pgTable('sync_state', {
-	/** Constant `'autumn'`. */
 	id: text('id').primaryKey(),
-	/** Null until the first full backfill has run. */
 	backfilledAt: timestamp('backfilled_at', { withTimezone: true }),
 	lastSyncedAt: timestamp('last_synced_at', { withTimezone: true })
 });

--- a/web/src/lib/server/db/schema.ts
+++ b/web/src/lib/server/db/schema.ts
@@ -1,0 +1,41 @@
+import {
+	bigint,
+	date,
+	doublePrecision,
+	integer,
+	pgTable,
+	primaryKey,
+	text,
+	timestamp
+} from 'drizzle-orm/pg-core';
+
+/**
+ * Pre-computed daily usage rollups — one row per (UTC day, model). The homepage stats are all
+ * derivable from these rows, so a page view never has to touch Autumn. The daily Vercel cron
+ * recomputes recent days and replaces them (see `syncUsage` in `$lib/server/usage`).
+ */
+export const usageDaily = pgTable(
+	'usage_daily',
+	{
+		/** UTC day, "YYYY-MM-DD". */
+		date: date('date', { mode: 'string' }).notNull(),
+		/** Model id, e.g. "anthropic/claude-opus-4-8". */
+		model: text('model').notNull(),
+		/** input + output + cache_read + cache_write tokens summed over the day's events. */
+		tokens: bigint('tokens', { mode: 'number' }).notNull(),
+		/** Summed Autumn `value` (USD). */
+		spendUsd: doublePrecision('spend_usd').notNull(),
+		/** Number of contributing events. */
+		events: integer('events').notNull()
+	},
+	(t) => [primaryKey({ columns: [t.date, t.model] })]
+);
+
+/** Single-row sync cursor for the Autumn → DB rollup job. */
+export const syncState = pgTable('sync_state', {
+	/** Constant `'autumn'`. */
+	id: text('id').primaryKey(),
+	/** Null until the first full backfill has run. */
+	backfilledAt: timestamp('backfilled_at', { withTimezone: true }),
+	lastSyncedAt: timestamp('last_synced_at', { withTimezone: true })
+});

--- a/web/src/lib/server/github.ts
+++ b/web/src/lib/server/github.ts
@@ -1,0 +1,126 @@
+import { env } from '$env/dynamic/private';
+import type { ContributionDay, ContributionStats } from '$lib/github';
+
+// GitHub's contribution calendar for the trailing year, pulled live from the GraphQL API. Unlike the
+// Autumn usage feed (paged, capped, DB-backed), the whole calendar comes back in a single cheap query,
+// so there's no cron/DB here — just a short in-memory cache so page views share one round trip.
+// Server-only: the token must never reach the client. Auth: any GitHub token (a scopeless classic PAT
+// or a fine-grained token with read access) can read a public user's contribution calendar.
+
+const GRAPHQL_URL = 'https://api.github.com/graphql';
+const DEFAULT_USERNAME = 'janburzinski';
+const CACHE_TTL_MS = 30 * 60_000;
+
+const LEVELS: Record<string, ContributionDay['level']> = {
+	NONE: 0,
+	FIRST_QUARTILE: 1,
+	SECOND_QUARTILE: 2,
+	THIRD_QUARTILE: 3,
+	FOURTH_QUARTILE: 4
+};
+
+const QUERY = `query($login: String!) {
+  user(login: $login) {
+    contributionsCollection {
+      contributionCalendar {
+        totalContributions
+        weeks {
+          contributionDays {
+            date
+            contributionCount
+            contributionLevel
+          }
+        }
+      }
+    }
+  }
+}`;
+
+type GqlDay = { date: string; contributionCount: number; contributionLevel: string };
+type GqlCalendar = { totalContributions: number; weeks: Array<{ contributionDays: GqlDay[] }> };
+type GqlResponse = {
+	data?: { user?: { contributionsCollection?: { contributionCalendar?: GqlCalendar } } };
+	errors?: Array<{ message: string }>;
+};
+
+/** Fold GitHub's calendar into the homepage's ContributionStats shape. */
+function buildStats(calendar: GqlCalendar): ContributionStats {
+	const weeks: ContributionDay[][] = calendar.weeks.map((w) =>
+		w.contributionDays.map((d) => ({
+			date: d.date,
+			count: d.contributionCount,
+			level: LEVELS[d.contributionLevel] ?? 0
+		}))
+	);
+
+	// weeks come oldest → newest and each day is in weekday order, so the flat list is chronological.
+	const days = weeks.flat();
+	let activeDays = 0;
+	let longest = 0;
+	let run = 0;
+	let busiest: { date: string; count: number } | null = null;
+	for (const d of days) {
+		if (d.count > 0) {
+			activeDays++;
+			run++;
+			if (run > longest) longest = run;
+		} else {
+			run = 0;
+		}
+		if (!busiest || d.count > busiest.count) busiest = { date: d.date, count: d.count };
+	}
+
+	// Current streak walks back from the newest day. If today (the last cell) is still empty, skip it
+	// rather than reporting a broken streak — it's an in-progress day, exactly how GitHub reads it.
+	let current = 0;
+	let i = days.length - 1;
+	if (i >= 0 && days[i].count === 0) i--;
+	for (; i >= 0 && days[i].count > 0; i--) current++;
+
+	return {
+		updatedAt: Date.now(),
+		total: calendar.totalContributions,
+		activeDays,
+		longestStreak: longest,
+		currentStreak: current,
+		busiestDay: busiest && busiest.count > 0 ? busiest : null,
+		weeks
+	};
+}
+
+// Short in-memory cache — same rationale as the usage stats: bursts of page views on a warm instance
+// share one GitHub call, and a cold start just refetches (the calendar changes at most once a day).
+let cache: { at: number; stats: ContributionStats } | null = null;
+
+export async function getContributionStats(): Promise<ContributionStats> {
+	if (cache && Date.now() - cache.at < CACHE_TTL_MS) return cache.stats;
+
+	const token = env.GITHUB_TOKEN;
+	if (!token) throw new Error('GITHUB_TOKEN is not set');
+	const login = env.GITHUB_USERNAME || DEFAULT_USERNAME;
+
+	const res = await fetch(GRAPHQL_URL, {
+		method: 'POST',
+		headers: {
+			Authorization: `Bearer ${token}`,
+			'Content-Type': 'application/json',
+			'User-Agent': 'janburzinski.de'
+		},
+		body: JSON.stringify({ query: QUERY, variables: { login } })
+	});
+	if (!res.ok) {
+		const text = await res.text();
+		throw new Error(`GitHub GraphQL failed (${res.status}): ${text.slice(0, 200)}`);
+	}
+
+	const payload = (await res.json()) as GqlResponse;
+	if (payload.errors?.length) {
+		throw new Error(`GitHub GraphQL error: ${payload.errors.map((e) => e.message).join('; ')}`);
+	}
+	const calendar = payload.data?.user?.contributionsCollection?.contributionCalendar;
+	if (!calendar) throw new Error('GitHub returned no contribution calendar');
+
+	const stats = buildStats(calendar);
+	cache = { at: Date.now(), stats };
+	return stats;
+}

--- a/web/src/lib/server/github.ts
+++ b/web/src/lib/server/github.ts
@@ -1,12 +1,6 @@
 import { env } from '$env/dynamic/private';
 import type { ContributionDay, ContributionStats } from '$lib/github';
 
-// GitHub's contribution calendar for the trailing year, pulled live from the GraphQL API. Unlike the
-// Autumn usage feed (paged, capped, DB-backed), the whole calendar comes back in a single cheap query,
-// so there's no cron/DB here — just a short in-memory cache so page views share one round trip.
-// Server-only: the token must never reach the client. Auth: any GitHub token (a scopeless classic PAT
-// or a fine-grained token with read access) can read a public user's contribution calendar.
-
 const GRAPHQL_URL = 'https://api.github.com/graphql';
 const DEFAULT_USERNAME = 'janburzinski';
 const CACHE_TTL_MS = 30 * 60_000;
@@ -43,7 +37,6 @@ type GqlResponse = {
 	errors?: Array<{ message: string }>;
 };
 
-/** Fold GitHub's calendar into the homepage's ContributionStats shape. */
 function buildStats(calendar: GqlCalendar): ContributionStats {
 	const weeks: ContributionDay[][] = calendar.weeks.map((w) =>
 		w.contributionDays.map((d) => ({
@@ -53,7 +46,6 @@ function buildStats(calendar: GqlCalendar): ContributionStats {
 		}))
 	);
 
-	// weeks come oldest → newest and each day is in weekday order, so the flat list is chronological.
 	const days = weeks.flat();
 	let activeDays = 0;
 	let longest = 0;
@@ -70,8 +62,7 @@ function buildStats(calendar: GqlCalendar): ContributionStats {
 		if (!busiest || d.count > busiest.count) busiest = { date: d.date, count: d.count };
 	}
 
-	// Current streak walks back from the newest day. If today (the last cell) is still empty, skip it
-	// rather than reporting a broken streak — it's an in-progress day, exactly how GitHub reads it.
+	// An empty current day doesn't break the streak yet.
 	let current = 0;
 	let i = days.length - 1;
 	if (i >= 0 && days[i].count === 0) i--;
@@ -88,39 +79,45 @@ function buildStats(calendar: GqlCalendar): ContributionStats {
 	};
 }
 
-// Short in-memory cache — same rationale as the usage stats: bursts of page views on a warm instance
-// share one GitHub call, and a cold start just refetches (the calendar changes at most once a day).
 let cache: { at: number; stats: ContributionStats } | null = null;
+let pending: Promise<ContributionStats> | null = null;
 
 export async function getContributionStats(): Promise<ContributionStats> {
 	if (cache && Date.now() - cache.at < CACHE_TTL_MS) return cache.stats;
+	if (pending) return pending;
 
-	const token = env.GITHUB_TOKEN;
-	if (!token) throw new Error('GITHUB_TOKEN is not set');
-	const login = env.GITHUB_USERNAME || DEFAULT_USERNAME;
+	pending = (async () => {
+		const token = env.GITHUB_TOKEN;
+		if (!token) throw new Error('GITHUB_TOKEN is not set');
+		const login = env.GITHUB_USERNAME || DEFAULT_USERNAME;
 
-	const res = await fetch(GRAPHQL_URL, {
-		method: 'POST',
-		headers: {
-			Authorization: `Bearer ${token}`,
-			'Content-Type': 'application/json',
-			'User-Agent': 'janburzinski.de'
-		},
-		body: JSON.stringify({ query: QUERY, variables: { login } })
+		const res = await fetch(GRAPHQL_URL, {
+			method: 'POST',
+			headers: {
+				Authorization: `Bearer ${token}`,
+				'Content-Type': 'application/json',
+				'User-Agent': 'janburzinski.de'
+			},
+			body: JSON.stringify({ query: QUERY, variables: { login } })
+		});
+		if (!res.ok) {
+			const text = await res.text();
+			throw new Error(`GitHub GraphQL failed (${res.status}): ${text.slice(0, 200)}`);
+		}
+
+		const payload = (await res.json()) as GqlResponse;
+		if (payload.errors?.length) {
+			throw new Error(`GitHub GraphQL error: ${payload.errors.map((e) => e.message).join('; ')}`);
+		}
+		const calendar = payload.data?.user?.contributionsCollection?.contributionCalendar;
+		if (!calendar) throw new Error('GitHub returned no contribution calendar');
+
+		const stats = buildStats(calendar);
+		cache = { at: Date.now(), stats };
+		return stats;
+	})().finally(() => {
+		pending = null;
 	});
-	if (!res.ok) {
-		const text = await res.text();
-		throw new Error(`GitHub GraphQL failed (${res.status}): ${text.slice(0, 200)}`);
-	}
 
-	const payload = (await res.json()) as GqlResponse;
-	if (payload.errors?.length) {
-		throw new Error(`GitHub GraphQL error: ${payload.errors.map((e) => e.message).join('; ')}`);
-	}
-	const calendar = payload.data?.user?.contributionsCollection?.contributionCalendar;
-	if (!calendar) throw new Error('GitHub returned no contribution calendar');
-
-	const stats = buildStats(calendar);
-	cache = { at: Date.now(), stats };
-	return stats;
+	return pending;
 }

--- a/web/src/lib/server/usage.ts
+++ b/web/src/lib/server/usage.ts
@@ -1,0 +1,186 @@
+import { gte } from 'drizzle-orm';
+import type { DailyUsage, UsageStats } from '$lib/usage';
+import {
+	eventsToDailyRollups,
+	fetchEventsSince,
+	resolveCustomerId,
+	type DailyRollup
+} from './autumn';
+import { getDb } from './db';
+import { syncState, usageDaily } from './db/schema';
+
+// Server-side orchestration for the homepage usage stats. Reads are served entirely from the
+// `usage_daily` rollups (no Autumn call on a page view); the daily cron calls `syncUsage` to pull
+// fresh events from Autumn and replace recent rollups. See the flow in `.context/attachments`.
+
+const DAY_MS = 86_400_000;
+/**
+ * Incremental sync recomputes the trailing N UTC days on every run — catches the in-progress day
+ * plus any late-arriving events, while everything older is treated as settled and never re-fetched.
+ */
+const RECOMPUTE_DAYS = 3;
+
+const dayKey = (ms: number) => new Date(ms).toISOString().slice(0, 10);
+const rollupToRow = (r: DailyRollup) => ({
+	date: r.date,
+	model: r.model,
+	tokens: r.tokens,
+	spendUsd: r.spendUsd,
+	events: r.events
+});
+
+/** Longest run of consecutive UTC days present in the (sorted, unique) day set. */
+function longestStreak(days: string[]): number {
+	if (!days.length) return 0;
+	const ms = days.map((d) => Date.parse(`${d}T00:00:00Z`)).sort((a, b) => a - b);
+	let best = 1;
+	let run = 1;
+	for (let i = 1; i < ms.length; i++) {
+		run = ms[i] - ms[i - 1] === DAY_MS ? run + 1 : 1;
+		if (run > best) best = run;
+	}
+	return best;
+}
+
+type UsageRow = typeof usageDaily.$inferSelect;
+
+/** Fold the flat (date, model) rows back into the homepage's UsageStats shape. */
+function buildStats(rows: UsageRow[], updatedAt: number): UsageStats {
+	const byDay = new Map<string, { tokens: number; spendUsd: number; models: UsageRow[] }>();
+	const modelTotals = new Map<string, number>();
+	let tokens = 0;
+	let spendUsd = 0;
+	let contributions = 0;
+
+	for (const row of rows) {
+		tokens += row.tokens;
+		spendUsd += row.spendUsd;
+		contributions += row.events;
+		modelTotals.set(row.model, (modelTotals.get(row.model) ?? 0) + row.tokens);
+
+		let bucket = byDay.get(row.date);
+		if (!bucket) {
+			bucket = { tokens: 0, spendUsd: 0, models: [] };
+			byDay.set(row.date, bucket);
+		}
+		bucket.tokens += row.tokens;
+		bucket.spendUsd += row.spendUsd;
+		bucket.models.push(row);
+	}
+
+	const days = [...byDay.keys()].sort();
+	const daily: DailyUsage[] = days.map((date) => {
+		const bucket = byDay.get(date)!;
+		return {
+			date,
+			tokens: bucket.tokens,
+			spendUsd: bucket.spendUsd,
+			models: bucket.models
+				.map((m) => ({ model: m.model, tokens: m.tokens }))
+				.sort((a, b) => b.tokens - a.tokens)
+		};
+	});
+
+	const topModel = [...modelTotals.entries()].sort((a, b) => b[1] - a[1])[0]?.[0] ?? null;
+
+	return {
+		updatedAt,
+		totals: {
+			tokens,
+			contributions,
+			activeDays: days.length,
+			longestStreak: longestStreak(days),
+			spendUsd,
+			topModel
+		},
+		daily
+	};
+}
+
+// Short in-memory cache so bursts of page views on a warm instance share one DB round trip. It
+// doesn't survive cold starts (that's fine — the data only changes once a day via the cron).
+const CACHE_TTL_MS = 60_000;
+let cache: { at: number; stats: UsageStats } | null = null;
+
+export async function getUsageStats(): Promise<UsageStats> {
+	if (cache && Date.now() - cache.at < CACHE_TTL_MS) return cache.stats;
+	const db = getDb();
+	const [rows, state] = await Promise.all([
+		db.select().from(usageDaily),
+		db.select().from(syncState).limit(1)
+	]);
+	const updatedAt = state[0]?.lastSyncedAt?.getTime() ?? Date.now();
+	const stats = buildStats(rows, updatedAt);
+	cache = { at: Date.now(), stats };
+	return stats;
+}
+
+export type SyncReport = {
+	mode: 'backfill' | 'incremental';
+	customerId: string | null;
+	events: number;
+	rows: number;
+	/** Present on incremental runs — the inclusive UTC start date of the recomputed window. */
+	windowStart?: string;
+};
+
+/**
+ * Pull events from Autumn and replace the affected rollups in one transaction.
+ *
+ * - **Backfill** (forced with `full`, or automatic until the first backfill has run): page over the
+ *   entire history uncapped, then `DELETE` every rollup and re-insert. Sets `backfilled_at`.
+ * - **Incremental**: fetch only events in the trailing `RECOMPUTE_DAYS` window, then `DELETE` rows
+ *   with `date >= windowStart` and re-insert the freshly computed ones. Older days are never touched.
+ *
+ * Both are recompute-replace (not additive), so a re-run over the same window produces identical
+ * rows — idempotent, no double counting.
+ */
+export async function syncUsage(opts: { full?: boolean } = {}): Promise<SyncReport> {
+	const db = getDb();
+	const now = Date.now();
+	const existing = await db.select().from(syncState).limit(1);
+	const backfilled = existing[0]?.backfilledAt != null;
+	const full = opts.full === true || !backfilled;
+
+	const customerId = await resolveCustomerId();
+	if (!customerId) {
+		return { mode: full ? 'backfill' : 'incremental', customerId: null, events: 0, rows: 0 };
+	}
+
+	if (full) {
+		const events = await fetchEventsSince(customerId, 0, Infinity);
+		const rollups = eventsToDailyRollups(events);
+		await db.transaction(async (tx) => {
+			await tx.delete(usageDaily);
+			if (rollups.length) await tx.insert(usageDaily).values(rollups.map(rollupToRow));
+			await tx
+				.insert(syncState)
+				.values({ id: 'autumn', backfilledAt: new Date(now), lastSyncedAt: new Date(now) })
+				.onConflictDoUpdate({
+					target: syncState.id,
+					set: { backfilledAt: new Date(now), lastSyncedAt: new Date(now) }
+				});
+		});
+		return { mode: 'backfill', customerId, events: events.length, rows: rollups.length };
+	}
+
+	const windowStartMs = Date.parse(`${dayKey(now)}T00:00:00Z`) - RECOMPUTE_DAYS * DAY_MS;
+	const windowStart = dayKey(windowStartMs);
+	const events = await fetchEventsSince(customerId, windowStartMs);
+	const rollups = eventsToDailyRollups(events);
+	await db.transaction(async (tx) => {
+		await tx.delete(usageDaily).where(gte(usageDaily.date, windowStart));
+		if (rollups.length) await tx.insert(usageDaily).values(rollups.map(rollupToRow));
+		await tx
+			.insert(syncState)
+			.values({ id: 'autumn', lastSyncedAt: new Date(now) })
+			.onConflictDoUpdate({ target: syncState.id, set: { lastSyncedAt: new Date(now) } });
+	});
+	return {
+		mode: 'incremental',
+		customerId,
+		events: events.length,
+		rows: rollups.length,
+		windowStart
+	};
+}

--- a/web/src/lib/server/usage.ts
+++ b/web/src/lib/server/usage.ts
@@ -9,15 +9,7 @@ import {
 import { getDb } from './db';
 import { syncState, usageDaily } from './db/schema';
 
-// Server-side orchestration for the homepage usage stats. Reads are served entirely from the
-// `usage_daily` rollups (no Autumn call on a page view); the daily cron calls `syncUsage` to pull
-// fresh events from Autumn and replace recent rollups. See the flow in `.context/attachments`.
-
 const DAY_MS = 86_400_000;
-/**
- * Incremental sync recomputes the trailing N UTC days on every run — catches the in-progress day
- * plus any late-arriving events, while everything older is treated as settled and never re-fetched.
- */
 const RECOMPUTE_DAYS = 3;
 
 const dayKey = (ms: number) => new Date(ms).toISOString().slice(0, 10);
@@ -44,7 +36,6 @@ function longestStreak(days: string[]): number {
 
 type UsageRow = typeof usageDaily.$inferSelect;
 
-/** Fold the flat (date, model) rows back into the homepage's UsageStats shape. */
 function buildStats(rows: UsageRow[], updatedAt: number): UsageStats {
 	const byDay = new Map<string, { tokens: number; spendUsd: number; models: UsageRow[] }>();
 	const modelTotals = new Map<string, number>();
@@ -68,9 +59,9 @@ function buildStats(rows: UsageRow[], updatedAt: number): UsageStats {
 		bucket.models.push(row);
 	}
 
-	const days = [...byDay.keys()].sort();
-	const daily: DailyUsage[] = days.map((date) => {
-		const bucket = byDay.get(date)!;
+	const entries = [...byDay.entries()].sort(([a], [b]) => a.localeCompare(b));
+	const days = entries.map(([date]) => date);
+	const daily: DailyUsage[] = entries.map(([date, bucket]) => {
 		return {
 			date,
 			tokens: bucket.tokens,
@@ -97,8 +88,6 @@ function buildStats(rows: UsageRow[], updatedAt: number): UsageStats {
 	};
 }
 
-// Short in-memory cache so bursts of page views on a warm instance share one DB round trip. It
-// doesn't survive cold starts (that's fine — the data only changes once a day via the cron).
 const CACHE_TTL_MS = 60_000;
 let cache: { at: number; stats: UsageStats } | null = null;
 
@@ -120,17 +109,18 @@ export type SyncReport = {
 	customerId: string | null;
 	events: number;
 	rows: number;
-	/** Present on incremental runs — the inclusive UTC start date of the recomputed window. */
 	windowStart?: string;
 };
 
 /**
  * Pull events from Autumn and replace the affected rollups in one transaction.
  *
- * - **Backfill** (forced with `full`, or automatic until the first backfill has run): page over the
- *   entire history uncapped, then `DELETE` every rollup and re-insert. Sets `backfilled_at`.
- * - **Incremental**: fetch only events in the trailing `RECOMPUTE_DAYS` window, then `DELETE` rows
- *   with `date >= windowStart` and re-insert the freshly computed ones. Older days are never touched.
+ * - **Backfill**: only runs when explicitly forced with `full`; it pages over the entire history,
+ *   then `DELETE`s every rollup and re-inserts. Keeping it off the cron path prevents a large initial
+ *   history from becoming an unbounded daily retry loop.
+ * - **Incremental** (including the first scheduled run): fetch only events in the trailing
+ *   `RECOMPUTE_DAYS` window, then `DELETE` rows with `date >= windowStart` and re-insert the freshly
+ *   computed ones. Older days are never touched.
  *
  * Both are recompute-replace (not additive), so a re-run over the same window produces identical
  * rows — idempotent, no double counting.
@@ -138,9 +128,7 @@ export type SyncReport = {
 export async function syncUsage(opts: { full?: boolean } = {}): Promise<SyncReport> {
 	const db = getDb();
 	const now = Date.now();
-	const existing = await db.select().from(syncState).limit(1);
-	const backfilled = existing[0]?.backfilledAt != null;
-	const full = opts.full === true || !backfilled;
+	const full = opts.full === true;
 
 	const customerId = await resolveCustomerId();
 	if (!customerId) {

--- a/web/src/lib/usage.ts
+++ b/web/src/lib/usage.ts
@@ -1,11 +1,7 @@
-// Shared usage-stats shapes. Kept out of $lib/server so client components can import the types.
-
 export type DailyUsage = {
-	/** UTC day, YYYY-MM-DD. */
 	date: string;
 	tokens: number;
 	spendUsd: number;
-	/** Token totals per model, biggest first. */
 	models: Array<{ model: string; tokens: number }>;
 };
 
@@ -13,14 +9,11 @@ export type UsageStats = {
 	updatedAt: number;
 	totals: {
 		tokens: number;
-		/** Number of tracked requests. */
 		contributions: number;
 		activeDays: number;
 		longestStreak: number;
 		spendUsd: number;
-		/** Model id with the most tokens overall (e.g. "anthropic/claude-opus-4-8"). */
 		topModel: string | null;
 	};
-	/** Ascending by date, one entry per day that had usage. */
 	daily: DailyUsage[];
 };

--- a/web/src/lib/usage.ts
+++ b/web/src/lib/usage.ts
@@ -1,0 +1,26 @@
+// Shared usage-stats shapes. Kept out of $lib/server so client components can import the types.
+
+export type DailyUsage = {
+	/** UTC day, YYYY-MM-DD. */
+	date: string;
+	tokens: number;
+	spendUsd: number;
+	/** Token totals per model, biggest first. */
+	models: Array<{ model: string; tokens: number }>;
+};
+
+export type UsageStats = {
+	updatedAt: number;
+	totals: {
+		tokens: number;
+		/** Number of tracked requests. */
+		contributions: number;
+		activeDays: number;
+		longestStreak: number;
+		spendUsd: number;
+		/** Model id with the most tokens overall (e.g. "anthropic/claude-opus-4-8"). */
+		topModel: string | null;
+	};
+	/** Ascending by date, one entry per day that had usage. */
+	daily: DailyUsage[];
+};

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -29,6 +29,9 @@
 			--text-secondary: #888;
 			--text-muted: #666;
 			--link-color: #e8e8e8;
+			--surface: #1c1c1f;
+			--surface-border: #2c2c30;
+			--surface-shadow: 0 8px 24px rgba(0, 0, 0, 0.35);
 		}
 
 		:root.light {
@@ -39,6 +42,9 @@
 			--text-secondary: #666;
 			--text-muted: #999;
 			--link-color: #1a1a1a;
+			--surface: #ffffff;
+			--surface-border: #e6e6e6;
+			--surface-shadow: 0 8px 24px rgba(0, 0, 0, 0.12);
 		}
 
 		body {

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -4,19 +4,21 @@ import { getContributionStats } from '$lib/server/github';
 import type { UsageStats } from '$lib/usage';
 import type { ContributionStats } from '$lib/github';
 
-export const load: PageServerLoad = async () => {
-	// Load both independently and never let a flaky read take down the homepage — a failed section
-	// just resolves to null and hides itself.
-	const [usage, contributions] = await Promise.all([
-		getUsageStats().catch((error): UsageStats | null => {
+// Cache rendered pages at the edge and ignore tracking parameters when selecting a cache entry.
+export const config = {
+	isr: { expiration: 3600, allowQuery: [] }
+};
+
+export const load: PageServerLoad = () => {
+	// Returning promises lets both optional sections stream independently.
+	return {
+		usage: getUsageStats().catch((error): UsageStats | null => {
 			console.error('[usage] failed to load usage stats:', error);
 			return null;
 		}),
-		getContributionStats().catch((error): ContributionStats | null => {
+		contributions: getContributionStats().catch((error): ContributionStats | null => {
 			console.error('[github] failed to load contribution stats:', error);
 			return null;
 		})
-	]);
-
-	return { usage, contributions };
+	};
 };

--- a/web/src/routes/+page.server.ts
+++ b/web/src/routes/+page.server.ts
@@ -1,0 +1,22 @@
+import type { PageServerLoad } from './$types';
+import { getUsageStats } from '$lib/server/usage';
+import { getContributionStats } from '$lib/server/github';
+import type { UsageStats } from '$lib/usage';
+import type { ContributionStats } from '$lib/github';
+
+export const load: PageServerLoad = async () => {
+	// Load both independently and never let a flaky read take down the homepage — a failed section
+	// just resolves to null and hides itself.
+	const [usage, contributions] = await Promise.all([
+		getUsageStats().catch((error): UsageStats | null => {
+			console.error('[usage] failed to load usage stats:', error);
+			return null;
+		}),
+		getContributionStats().catch((error): ContributionStats | null => {
+			console.error('[github] failed to load contribution stats:', error);
+			return null;
+		})
+	]);
+
+	return { usage, contributions };
+};

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
-	import { Github, Mail, Sun, Moon, ArrowUpRight } from 'lucide-svelte';
+	import { Github, Mail, Linkedin, Sun, Moon, ArrowUpRight } from 'lucide-svelte';
 	import { onMount } from 'svelte';
+	import UsageSection from '$lib/components/UsageSection.svelte';
+	import ContributionSection from '$lib/components/ContributionSection.svelte';
+
+	export let data;
 
 	type Theme = 'light' | 'dark';
 	let theme: Theme = 'dark';
@@ -43,7 +47,12 @@
 		<div class="nav-right">
 			<a href="/impressum" class="nav-link">Imprint</a>
 			<a href="/datenschutz" class="nav-link">Privacy</a>
-			<button class="nav-icon theme-toggle" on:click={toggleTheme} aria-label="Toggle theme" type="button">
+			<button
+				class="nav-icon theme-toggle"
+				on:click={toggleTheme}
+				aria-label="Toggle theme"
+				type="button"
+			>
 				{#if theme === 'light'}
 					<Sun size={16} />
 				{:else}
@@ -55,13 +64,33 @@
 
 	<div class="main">
 		<p>
-			Computer Science student at <a href="https://tu.berlin" target="_blank" rel="noopener noreferrer">TU Berlin</a>, 21 years old. My passion for software was sparked by Minecraft. I've been building things ever since.
+			Computer Science student at <a
+				href="https://tu.berlin"
+				target="_blank"
+				rel="noopener noreferrer">TU Berlin</a
+			>, 21 years old. My passion for software was sparked by Minecraft. I've been building things
+			ever since.
 		</p>
 
 		<div class="social-links">
-			<a href="https://github.com/janburzinski" target="_blank" rel="noopener noreferrer" class="social-link">
+			<a
+				href="https://github.com/janburzinski"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="social-link"
+			>
 				<Github size={16} />
 				<span>GitHub</span>
+				<ArrowUpRight size={13} class="outbound" />
+			</a>
+			<a
+				href="https://www.linkedin.com/in/jan-burzinski-2a76b1333/"
+				target="_blank"
+				rel="noopener noreferrer"
+				class="social-link"
+			>
+				<Linkedin size={16} />
+				<span>LinkedIn</span>
 				<ArrowUpRight size={13} class="outbound" />
 			</a>
 			<a href="mailto:jan@burzinski.de" class="social-link">
@@ -70,6 +99,14 @@
 				<ArrowUpRight size={13} class="outbound" />
 			</a>
 		</div>
+
+		{#if data.usage}
+			<UsageSection stats={data.usage} />
+		{/if}
+
+		{#if data.contributions}
+			<ContributionSection stats={data.contributions} />
+		{/if}
 	</div>
 </div>
 

--- a/web/src/routes/+page.svelte
+++ b/web/src/routes/+page.svelte
@@ -100,13 +100,17 @@
 			</a>
 		</div>
 
-		{#if data.usage}
-			<UsageSection stats={data.usage} />
-		{/if}
+		{#await data.usage then usage}
+			{#if usage}
+				<UsageSection stats={usage} />
+			{/if}
+		{/await}
 
-		{#if data.contributions}
-			<ContributionSection stats={data.contributions} />
-		{/if}
+		{#await data.contributions then contributions}
+			{#if contributions}
+				<ContributionSection stats={contributions} />
+			{/if}
+		{/await}
 	</div>
 </div>
 

--- a/web/src/routes/api/sync/+server.ts
+++ b/web/src/routes/api/sync/+server.ts
@@ -1,0 +1,23 @@
+import { env } from '$env/dynamic/private';
+import { json, type RequestHandler } from '@sveltejs/kit';
+import { syncUsage } from '$lib/server/usage';
+
+// Daily Autumn → DB sync, driven by Vercel Cron (see vercel.json). Vercel automatically attaches
+// `Authorization: Bearer <CRON_SECRET>` to scheduled invocations when CRON_SECRET is set, which is
+// what we check here so the endpoint isn't publicly triggerable. `?full=1` forces a full backfill.
+export const GET: RequestHandler = async ({ request, url }) => {
+	const secret = env.CRON_SECRET;
+	if (!secret) return json({ error: 'CRON_SECRET is not set' }, { status: 500 });
+	if (request.headers.get('authorization') !== `Bearer ${secret}`) {
+		return json({ error: 'unauthorized' }, { status: 401 });
+	}
+
+	const full = url.searchParams.get('full') === '1';
+	try {
+		const report = await syncUsage({ full });
+		return json({ ok: true, ...report });
+	} catch (error) {
+		console.error('[sync] failed:', error);
+		return json({ ok: false, error: String(error) }, { status: 500 });
+	}
+};

--- a/web/src/routes/api/sync/+server.ts
+++ b/web/src/routes/api/sync/+server.ts
@@ -2,9 +2,7 @@ import { env } from '$env/dynamic/private';
 import { json, type RequestHandler } from '@sveltejs/kit';
 import { syncUsage } from '$lib/server/usage';
 
-// Daily Autumn → DB sync, driven by Vercel Cron (see vercel.json). Vercel automatically attaches
-// `Authorization: Bearer <CRON_SECRET>` to scheduled invocations when CRON_SECRET is set, which is
-// what we check here so the endpoint isn't publicly triggerable. `?full=1` forces a full backfill.
+// Vercel Cron authenticates this endpoint with CRON_SECRET; full syncs remain explicit.
 export const GET: RequestHandler = async ({ request, url }) => {
 	const secret = env.CRON_SECRET;
 	if (!secret) return json({ error: 'CRON_SECRET is not set' }, { status: 500 });

--- a/web/src/routes/datenschutz/+page.svelte
+++ b/web/src/routes/datenschutz/+page.svelte
@@ -42,8 +42,8 @@
 		<div class="section">
 			<h2>4. Ihre Rechte</h2>
 			<p>
-				Sie haben das Recht auf Auskunft, Berichtigung oder Löschung Ihrer Daten. Kontaktieren Sie uns
-				gerne per E-Mail.
+				Sie haben das Recht auf Auskunft, Berichtigung oder Löschung Ihrer Daten. Kontaktieren Sie
+				uns gerne per E-Mail.
 			</p>
 		</div>
 

--- a/web/vercel.json
+++ b/web/vercel.json
@@ -1,0 +1,3 @@
+{
+	"crons": [{ "path": "/api/sync", "schedule": "0 4 * * *" }]
+}


### PR DESCRIPTION
Adds a server-backed AI usage dashboard using Autumn event rollups stored in PlanetScale Postgres and refreshed by a protected daily Vercel cron.

Adds a cached GitHub contribution calendar, dithered interactive charts, summary panels, LinkedIn profile link, and supporting theme styling.

Includes Drizzle configuration, deployment/environment documentation, and ignores local environment files.

Validated with `pnpm --dir web check` and `pnpm --dir web lint`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a server-backed usage dashboard and GitHub activity charts to the homepage. Data syncs daily and the page uses ISR for fast loads.

- **New Features**
  - Usage: pull Autumn events, roll up by day/model into Postgres via `drizzle-orm`; `/api/sync` (guarded by `CRON_SECRET`) runs on Vercel Cron; recent 3 days are re-computed to correct late events; totals include tokens, spend, contributions, active days, longest streak, and top model; interactive dithered chart reads only from the DB.
  - GitHub: fetch the contribution calendar via GraphQL using `GITHUB_TOKEN`, cache for 30 minutes; interactive grid with totals, active days, longest and current streaks, and busiest day.
  - UI: collapsible stats panels, dithered charts with tooltips, theme surface tokens, LinkedIn link, and minor polish.
  - Caching: homepage rendered with ISR (60 min) at the edge.
  - Repo: ignore `.vercel/` project metadata.

- **Migration**
  - Set env vars: `AUTUMN_SECRET_KEY`, `GITHUB_TOKEN`, optional `GITHUB_USERNAME`, `DATABASE_URL`, `DATABASE_DIRECT_URL`, `CRON_SECRET`.
  - Initialize the DB: `pnpm --dir web db:push` (or `db:migrate`).
  - Ensure Vercel Cron is enabled (in `vercel.json`), set `CRON_SECRET`, then backfill once: `GET /api/sync?full=1` with `Authorization: Bearer <CRON_SECRET>`.

<sup>Written for commit 32aeeb7d1ea8382e5580b5ea6b07d4a102069246. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/janburzinski/janburzinski.de/pull/3?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

