### PR TITLE
Fix AI usage chart color flash

### DIFF
--- a/web/src/lib/components/CollapsibleStatsSection.svelte
+++ b/web/src/lib/components/CollapsibleStatsSection.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { ChevronDown } from 'lucide-svelte';
+	import { cubicOut } from 'svelte/easing';
 	import type { Snippet } from 'svelte';
-	import { slide } from 'svelte/transition';
 
 	type StatRow = { label: string; value: string };
 
@@ -18,6 +18,16 @@
 	} = $props();
 
 	let open = $state(false);
+
+	function expand(node: HTMLElement) {
+		const height = parseFloat(getComputedStyle(node).height);
+
+		return {
+			duration: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 0 : 200,
+			easing: cubicOut,
+			css: (t: number) => `overflow: hidden; height: ${t * height}px; min-height: 0;`
+		};
+	}
 </script>
 
 <section style:margin-top={marginTop}>
@@ -27,7 +37,7 @@
 	</button>
 
 	{#if open}
-		<div transition:slide={{ duration: 200 }}>
+		<div transition:expand>
 			<dl class="stats">
 				{#each rows as row (row.label)}
 					<div class="row">


### PR DESCRIPTION
## What changed

- replace Svelte's opacity-changing `slide` transition with a height-only expansion
- preserve the existing 200ms easing and disable it for reduced-motion users

## Why

The AI usage chart combines a crisp canvas with an additive bloom canvas. Svelte's built-in slide transition briefly changes the wrapper opacity, which changes how those layers are composited and makes the purple bars flash a different color while expanding.

## Validation

- `pnpm run check`
- `pnpm run lint`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a brief color flash in the AI usage chart when expanding the stats section by removing opacity changes during the transition.

Replaces Svelte’s `slide` (from `svelte/transition`) with a custom height-only expand that uses `cubicOut` from `svelte/easing`, keeps the 200ms duration, and disables animation for `prefers-reduced-motion`.

<sup>Written for commit 2fcd36ebb123119349fff4b61dabd23a00cd6fe4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/janburzinski/janburzinski.de/pull/4?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the expand and collapse animation for statistics sections.
  * Added support for reduced-motion preferences, disabling animation when requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->