### PR TITLE
Fix usage section expand jank

### DIFF
--- a/web/src/lib/components/CollapsibleStatsSection.svelte
+++ b/web/src/lib/components/CollapsibleStatsSection.svelte
@@ -37,7 +37,7 @@
 	</button>
 
 	{#if open}
-		<div transition:expand>
+		<div class="content" transition:expand>
 			<dl class="stats">
 				{#each rows as row (row.label)}
 					<div class="row">
@@ -55,6 +55,10 @@
 </section>
 
 <style>
+	.content {
+		display: flow-root;
+	}
+
 	.toggle {
 		display: inline-flex;
 		align-items: center;


### PR DESCRIPTION
## What changed

- establish a flow-root on the animated stats container
- keep the measured and animated accordion heights identical

## Why

The first stats row has a top margin that previously collapsed outside the container before measurement. During the height transition, `overflow: hidden` contained that margin, so Svelte had to correct the layout when the transition styles were removed. The resulting final-frame jump was visible as a brief stutter.

## Impact

The AI usage and GitHub activity sections now finish their expand animation without a layout correction. Chart tooltips remain unclipped.

## Validation

- `pnpm run check`
- `pnpm run lint`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the expand stutter in the AI usage and GitHub activity stats by wrapping the animated content in a flow-root container so margins don’t collapse during the `expand` transition. The animation now finishes smoothly without a final-frame jump; tooltips remain visible.

- **Bug Fixes**
  - Wrapped content in `div.content` and set `display: flow-root` to isolate margins and keep transition height stable.

<sup>Written for commit a35a0f2cb65d105c60ba3c37692e7b1877441d3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/janburzinski/janburzinski.de/pull/5?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

