### PR TITLE
Update privacy policy

### DIFF
--- a/web/src/routes/datenschutz/+page.svelte
+++ b/web/src/routes/datenschutz/+page.svelte
@@ -23,31 +23,115 @@
 		</div>
 
 		<div class="section">
-			<h2>2. Hosting & Bereitstellung</h2>
+			<h2>2. Hosting und Server-Logfiles</h2>
 			<p>
-				Diese Website wird bei Cloudflare gehostet (Cloudflare, Inc., 665 3rd St. Suite 200, San
-				Francisco, CA 94107, USA). Cloudflare speichert technische Daten zur Sicherheit und
-				Stabilität. Es werden keine personenbezogenen Daten auf den Servern gespeichert.
+				Diese Website wird über Vercel bereitgestellt. Anbieter ist die Vercel Inc., 440 N Barranca
+				Avenue #4133, Covina, CA 91723, USA.
+			</p>
+			<p>
+				Beim Aufruf der Website verarbeitet Vercel technisch erforderliche Daten. Dazu können
+				insbesondere IP-Adresse, Datum und Uhrzeit des Zugriffs, aufgerufene Seite, Referrer,
+				Browser-, Geräte- und Systeminformationen sowie Status-, Diagnose- und Leistungsdaten
+				gehören. Die Verarbeitung dient der Auslieferung, Stabilität und Sicherheit der Website und
+				der Abwehr missbräuchlicher Zugriffe. Rechtsgrundlage ist Art. 6 Abs. 1 lit. f DSGVO. Mein
+				berechtigtes Interesse liegt im sicheren und zuverlässigen Betrieb dieser Website.
+			</p>
+			<p>
+				Vercel kann Daten in den USA und weiteren Ländern verarbeiten. Weitere Informationen zu
+				Verarbeitung, Drittlandübermittlungen und Schutzmaßnahmen finden Sie in der
+				<a href="https://vercel.com/legal/privacy-notice" target="_blank" rel="noreferrer"
+					>Datenschutzerklärung</a
+				>
+				und dem
+				<a href="https://vercel.com/legal/dpa" target="_blank" rel="noreferrer"
+					>Data Processing Addendum</a
+				>
+				von Vercel. Technische Daten werden nur so lange gespeichert, wie dies für die genannten Zwecke
+				oder aufgrund gesetzlicher Pflichten erforderlich ist.
 			</p>
 		</div>
 
 		<div class="section">
-			<h2>3. Webanalyse</h2>
+			<h2>3. Webanalyse mit Databuddy</h2>
 			<p>
-				Wir nutzen anonymisierte Analyse-Tools zur Verbesserung unseres Angebots. Es werden keine
-				personenbezogenen Daten oder Cookies für Werbezwecke gespeichert.
+				Diese Website nutzt Databuddy, einen Dienst der Databuddy Analytics, Inc. Das
+				Databuddy-Skript wird von <code>cdn.databuddy.cc</code> geladen und hilft mir, Nutzung, Leistung
+				und technische Fehler der Website zu verstehen.
+			</p>
+			<p>
+				Dabei können insbesondere besuchte Seiten und Seitentitel, Referrer, Zeitstempel,
+				Aufenthaltsdauer, Scrolltiefe, ausgehende Interaktionen, Browser-, Geräte-, Sprach-,
+				Zeitzonen- und Bildschirmdaten, ungefähre Standortdaten, Kampagnenparameter,
+				Performancewerte und JavaScript-Fehler verarbeitet werden. Die IP-Adresse erreicht den
+				Server technisch bedingt. Nach Angaben von Databuddy wird sie zur Ermittlung einer
+				ungefähren Region und einer täglich wechselnden pseudonymen Signatur verwendet und danach
+				verworfen. Bei missbräuchlich vielen Anfragen kann sie vorübergehend für das Rate-Limiting
+				gespeichert werden.
+			</p>
+			<p>
+				Databuddy verwendet keine Cookies und kein websiteübergreifendes Tracking. Das Skript
+				speichert jedoch eine zufällige pseudonyme Kennung und gegebenenfalls Kampagneninformationen
+				im lokalen Speicher des Browsers sowie temporäre Sitzungsdaten im Sitzungsspeicher.
+				Databuddy berücksichtigt aktivierte Signale wie Do Not Track und Global Privacy Control.
+			</p>
+			<p>
+				Die Verarbeitung erfolgt auf Grundlage von Art. 6 Abs. 1 lit. f DSGVO. Mein berechtigtes
+				Interesse liegt in der datensparsamen Analyse und technischen Verbesserung der Website. Nach
+				Angaben von Databuddy werden Analysedaten innerhalb der EU verarbeitet. Die meisten
+				Analysedaten bleiben für die Dauer des aktiven Projekts gespeichert, Performancewerte werden
+				nach einem Jahr gelöscht. Weitere Informationen finden Sie in der
+				<a href="https://www.databuddy.cc/privacy" target="_blank" rel="noreferrer"
+					>Datenschutzerklärung</a
+				>, der
+				<a href="https://www.databuddy.cc/data-policy" target="_blank" rel="noreferrer"
+					>Datenrichtlinie</a
+				>
+				und der
+				<a href="https://www.databuddy.cc/dpa" target="_blank" rel="noreferrer"
+					>Auftragsverarbeitungsvereinbarung</a
+				>
+				von Databuddy.
 			</p>
 		</div>
 
 		<div class="section">
-			<h2>4. Ihre Rechte</h2>
+			<h2>4. Lokale Speicherung</h2>
 			<p>
-				Sie haben das Recht auf Auskunft, Berichtigung oder Löschung Ihrer Daten. Kontaktieren Sie
-				uns gerne per E-Mail.
+				Zusätzlich zur beschriebenen Speicherung durch Databuddy speichert diese Website Ihre
+				gewählte Farbdarstellung unter dem Schlüssel <code>theme</code> im lokalen Speicher Ihres Browsers.
+				Diese Einstellung wird nicht an mich übertragen und bleibt erhalten, bis Sie sie ändern oder den
+				lokalen Speicher löschen. Sie dient ausschließlich der von Ihnen gewählten Darstellung der Website.
 			</p>
 		</div>
 
-		<div class="meta">Letztes Update: 13.04.2026</div>
+		<div class="section">
+			<h2>5. Kontaktaufnahme</h2>
+			<p>
+				Wenn Sie mich per E-Mail kontaktieren, verarbeite ich die von Ihnen übermittelten Angaben
+				zur Bearbeitung Ihrer Anfrage. Rechtsgrundlage ist je nach Inhalt Art. 6 Abs. 1 lit. b oder
+				lit. f DSGVO. Die Daten werden gelöscht, sobald die Anfrage abschließend bearbeitet ist und
+				keine gesetzlichen Aufbewahrungspflichten entgegenstehen.
+			</p>
+		</div>
+
+		<div class="section">
+			<h2>6. Ihre Rechte</h2>
+			<p>
+				Sie haben im Rahmen der gesetzlichen Voraussetzungen das Recht auf Auskunft, Berichtigung,
+				Löschung, Einschränkung der Verarbeitung, Datenübertragbarkeit und Widerspruch gegen die
+				Verarbeitung Ihrer personenbezogenen Daten. Eine erteilte Einwilligung können Sie jederzeit
+				mit Wirkung für die Zukunft widerrufen.
+			</p>
+			<p>
+				Sie haben außerdem das Recht, sich bei einer Datenschutzaufsichtsbehörde zu beschweren,
+				insbesondere bei der
+				<a href="https://www.datenschutz-berlin.de/" target="_blank" rel="noreferrer"
+					>Berliner Beauftragten für Datenschutz und Informationsfreiheit</a
+				>. Zur Ausübung Ihrer Rechte können Sie sich an die oben genannte E-Mail-Adresse wenden.
+			</p>
+		</div>
+
+		<div class="meta">Letztes Update: 13.07.2026</div>
 	</div>
 </div>
 
@@ -120,6 +204,22 @@
 		line-height: 1.7;
 		color: var(--text-secondary);
 		margin: 0;
+	}
+
+	p + p {
+		margin-top: 0.75rem;
+	}
+
+	a {
+		color: var(--text-primary);
+		text-decoration: underline;
+		text-decoration-color: var(--text-muted);
+		text-underline-offset: 2px;
+	}
+
+	code {
+		font-family: 'Geist Mono', monospace;
+		font-size: 0.8125rem;
 	}
 
 	.meta {


### PR DESCRIPTION
## What changed

- replace the obsolete Cloudflare hosting disclosure with current Vercel hosting and log processing details
- document the active Databuddy analytics integration, browser storage, processed data, retention, and privacy controls
- add the functional theme preference, email contact processing, and complete data subject rights
- link the official provider privacy and processing documents

## Why

The privacy policy still described Cloudflare hosting and only referred to anonymous analytics in general terms. The site is hosted on Vercel and loads Databuddy globally, including pseudonymous local and session storage, so the existing disclosure no longer matched the deployed application.

## Validation

- `pnpm run check`
- `pnpm run lint`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the privacy policy to reflect Vercel hosting and Databuddy analytics, add local storage and rights details, and improve readability.

- New Features
  - Replace Cloudflare with Vercel hosting and server-log details, plus links to Vercel privacy and DPA.
  - Document Databuddy analytics: data points, EU processing, retention, Do Not Track/GPC support, local/session storage, script from `cdn.databuddy.cc`.
  - Add local theme preference stored under `theme` (not transmitted).
  - Add email contact processing and full data subject rights; update last modified date.

- Refactors
  - Tweak styles for paragraphs, links, and inline `code` for better legibility.

<sup>Written for commit 9edffee5493872d05ddaf0b41b14ac36c2cc1e16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/janburzinski/janburzinski.de/pull/6?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

